### PR TITLE
Include environment snapshot in ready endpoint payload

### DIFF
--- a/web/app/api/ready/route.test.ts
+++ b/web/app/api/ready/route.test.ts
@@ -56,5 +56,6 @@ describe("GET /api/ready", () => {
     expect(response.headers.get("content-type")).toContain("application/json");
     expect(response.headers.get(VERSION_HEADER_NAME)).toBe("commit-hash");
     expect(payload.ready).toBe(true);
+    expect(payload.env).toBe("production");
   });
 });

--- a/web/app/api/ready/route.ts
+++ b/web/app/api/ready/route.ts
@@ -15,12 +15,9 @@ import { applyVersionHeader } from "../../../lib/versionHeader";
 export function GET() {
   // Capture the environment name so operations teams can double-check context if needed.
   const envSnapshot = process.env.NODE_ENV ?? "development";
-  const readinessProbe = { env: envSnapshot };
-  // The void statement stops TypeScript from complaining that we never used the snapshot.
-  void readinessProbe.env;
 
   // Respond with a simple "ready" message.
-  const response = NextResponse.json({ ready: true });
+  const response = NextResponse.json({ ready: true, env: envSnapshot });
 
   // Stamp the outgoing response with our version header for traceability.
   return applyVersionHeader(response);


### PR DESCRIPTION
## Summary
- include the environment snapshot in the ready endpoint JSON response
- update the ready route test to expect the environment field

## Testing
- npm test *(fails: `vitest` unavailable because dependencies cannot be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca128ed1cc8321af59641971f54916