### PR TITLE
docs: establish repo policies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,36 @@
 # Agents Rules (Codex)
 
-- Use the branch I specify (e.g., `codex/<task>`). Do **not** create new branches.
-- Open exactly one PR to `main` using **squash merge**.
-- If checks fail, provide a diff/patch only—do not push.
-- Respect `.gitignore` (never commit `_evidence/` or build artefacts).
+These rules apply to any AI/code agent working in this repo (e.g., Codex).
+
+## Golden rules
+- **Branch**: Use the branch **explicitly named by the human** (e.g., `codex/<task>`). If it doesn’t exist, create **exactly that name**. Do **not** invent alternatives or create duplicates.
+- **PRs**: Open **one** PR to `main` and request **Squash merge**. Never push to `main` directly.
+- **Small diffs**: Keep PRs small and focused. If >300 lines changed, split into sequential PRs.
+- **Checks first**: Run lint/typecheck/build/tests locally. If checks fail, **do not push**—return a diff/patch and the exact errors.
+- **Respect `.gitignore`**: Never commit `_evidence/`, `web/.next/`, `node_modules/`, OS/editor files, or large/binary artefacts.
+- **No secrets**: Never commit `.env*` or credentials. If found, stop and request rotation.
+- **No history rewrites**: Never force-push to `main`. Feature branches only if the human asks.
+
+## Design canon
+- **Read before code**: You **must** read and comply with `docs/design-principles.md` and `docs/ux-principles.md`.
+- If you need to deviate, add an ADR (`docs/adr/ADR-YYYYMMDD-title.md`) and explain the trade-off.
+
+## Model Change Protocol (agents must follow)
+If you modify `prisma/schema.prisma`:
+1) Include a Prisma migration.
+2) Update `docs/domain-model.md` (entities/relations + ERD snippet + invariants).
+3) Update affected API contracts in `docs/api/` (or contract tables in the PR).
+4) Add/adjust seed data if needed.
+5) Add an ADR if the change is significant, breaking, or cross-cutting.
+6) One conceptual change **per PR** (don’t bundle unrelated schema edits).
+
+## Module boundaries
+- Layered shape: `domain/` (pure) ← `app/` (use-cases) ← `infra/` (adapters/IO) ← `web/` (Next.js UI). Imports point **up** only.
+- `web/` should call `app/` use-cases; it must not import `infra/` directly.
+- Narrow exceptions are defined in `docs/design-principles.md` (“Layering exceptions”).
+
+## PR requirements (include in description)
+- **Design compliance**: cite relevant sections of `docs/design-principles.md` and `docs/ux-principles.md`.
+- **Model compliance**: if schema changed, confirm migration + docs + contracts + (if needed) ADR.
+- **Testing**: list commands run and results.
+- **Risk & rollback**: expected impact and revert plan (squash revert or follow-up PR).

--- a/docs/design-principles.md
+++ b/docs/design-principles.md
@@ -1,0 +1,102 @@
+# RC Race Engineer — Design Principles
+
+This is the architectural north star. All code and PRs (human or agent) must align with these principles.
+
+## 0) System shape
+- **Layers**: `domain/` (pure logic, types) → `app/` (use-cases/orchestration) → `infra/` (IO: DB/HTTP/FS). `web/` (Next.js) consumes `app` only.
+- **Rule of arrows**: imports only point **upward**. `domain` depends on nothing.
+- **Docs**: decisions go to `docs/adr/`; contracts live in `docs/api/`.
+
+### Layering exceptions (narrow)
+To keep velocity without breaking the architecture, a few tightly-scoped exceptions are allowed:
+1) **Server-only utilities** in `web/` may call a **thin infra adapter** (e.g., feature flags, build/version, CDN asset manifest) **from server components or server actions only**. No client components may import `infra/`.
+2) **Third-party HTTP calls** (e.g., analytics, auth provider) can be made from `web/` **server runtime** via an exported adapter in `infra/public`. Prefer going through `app/` when the call affects core logic or data.
+3) **Realtime transport**: `web/` may attach to a realtime layer (WebSocket/SSE) whose **message schema** is owned by `domain/`. DB access still goes through `app/`.
+
+**Guardrails**: never import Prisma/DB clients in `web/`; no infra imports in client components; keep exceptions minimal and documented in the PR.
+
+## 1) Contracts first
+- Public endpoints & server actions are specified before code (brief tables or OpenAPI snippet).
+- Breaking changes require a new **version** and an ADR.
+- Validate at boundaries (e.g., Zod). Internals assume validated types.
+
+## 2) Pure core
+- Domain logic is pure & mostly synchronous. Side-effects are isolated in adapters.
+- Prefer plain data + functions over heavy classes.
+
+## 3) Use-cases
+- Each user/system goal is a single **use-case** function in `app/`.
+- Use-cases orchestrate calls through **ports** (interfaces) implemented in `infra/`.
+
+## 4) Errors & logging
+- Throw typed errors or return a `Result` type; don’t throw generic `Error` from deep inside.
+- Log **once at the boundary** (request/response) with correlation id, never within domain functions.
+
+## 5) Data & migrations
+- Prisma migrations are the source of truth. No manual DB edits.
+- Each migration is reversible or an ADR explains why not.
+- Avoid N+1: prefer explicit `select/include` and targeted indexes.
+
+## 6) Performance budgets
+**API**
+- Read endpoints (warm cache/typical payload): **p95 < 200ms**, **p99 < 500ms**.
+- Heavy/analytics endpoints (paginated/streamed): **p95 < 600ms**, **p99 < 1.2s**; must paginate or stream partials.
+- Internal service-to-service calls: **p95 < 150ms**.
+- DB queries: **p95 < 50ms**, **0 N+1** accepted in reviews.
+
+**Web**
+- Server-rendered TTFB **< 200ms**; **TTI < 1.8s** on mid hardware.
+- Core Web Vitals: **LCP < 2.0s**, **CLS < 0.1**, **INP p75 < 100ms (p95 < 200ms)**.
+- Interactions feel instant: async work shows skeletons; avoid spinners.
+
+**Measurement**
+- Capture p50/p95/p99 durations per endpoint and DB op; surface in `/ready` diagnostics.
+- PRs likely to affect budgets must include before/after notes.
+
+## 7) Security & secrets
+- No secrets in code/history; use env vars and a secrets store.
+- Least privilege for DB/API keys; scrub PII in logs.
+
+## 8) Observability
+- Standard fields: timestamp, level, message, correlationId, userId? (if applicable).
+- Emit req duration/error counts and key DB metrics.
+- Health/ready/version endpoints are truthful: ready = deps OK; health = process OK; version = git sha/tag.
+
+## 9) Naming & structure
+- Names describe intent (nouns for models, verbs for actions). One file = one concern.
+- No “misc” dumping grounds; split by domain concept.
+
+## 10) Testing
+- **Unit** for domain (fast, isolated, no IO).
+- **Integration** for infra boundaries (DB/API/FS).
+- **Contract** tests for public endpoints.
+- Each bug fix adds a failing test first.
+
+## 11) Accessibility & UX
+- Keyboard access, semantic HTML, WCAG AA contrast.
+- Units explicit and consistent (metric default unless configured).
+
+## 12) PR discipline
+- Small, focused diffs; split if >300 changed lines.
+- Conventional commits; PRs include summary, changes, tests, risks/rollback, and referenced principles.
+
+## 13) Visual grammar & tokens
+**Semantics → visuals (consistent across the app)**
+- **Speed**: blue line
+- **Throttle**: green area/line
+- **Brake**: red area/line
+- **RPM**: purple line
+- **Gear**: amber step-line
+- **Temperatures (tyre/brake/ambient/track)**: orange family (distinct shades)
+- **Flags/Events**: annotated markers with shapes + labels (not color-only)
+
+**Design tokens (light/dark)**
+- Colors: `--color-speed`, `--color-throttle`, `--color-brake`, `--color-rpm`, `--color-gear`, `--color-temp-tyre`, `--color-temp-brake`, `--color-ambient`, `--color-track`.
+- Typography scale: `--font-size-xs/sm/md/lg/xl/2xl`.
+- Spacing: `--space-1..8`.
+- Radii: `--radius-sm/md/lg/2xl`.
+
+**Rules**
+- Never rely on color alone; pair with shape/label.
+- Units are explicit; metric by default.
+- Same signal, same token, everywhere.

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -1,0 +1,94 @@
+# RC Race Engineer — Domain Model (Draft)
+
+This document is the source of truth for entities, relations, and invariants. PRs that change the model must update this document and follow the **Model Change Protocol** in `AGENTS.md`.
+
+## Entities (first pass)
+- **Team** *(optional if single-tenant)*
+- **User**
+- **Driver**
+- **Car**
+- **Track**
+- **Event** (e.g., race weekend)
+- **Session** (practice/qualifying/race)
+- **Lap**
+- **Stint**
+- **TelemetrySample** (time-series metrics per car)
+- **SetupSheet** (baseline + adjustments)
+- **WeatherSnapshot**
+- **TyreSet**
+- **Incident** (flags, notes, steward events)
+- **Annotation** (engineer notes tied to time/lap)
+
+## Relationships (rough)
+```mermaid
+graph TD
+  Team --< Users
+  Team --< Cars
+  Team --< Drivers
+  Event --> Track
+  Event --< Sessions
+  Session --< Stints
+  Session --< Laps
+  Stint --> Car
+  Stint --> Driver
+  Lap --> Session
+  Lap --> Car
+  TelemetrySample --> Session
+  TelemetrySample --> Car
+  TelemetrySample --> Driver
+  TelemetrySample --> Lap
+  SetupSheet --> Car
+  SetupSheet --> Session
+  WeatherSnapshot --> Session
+  TyreSet --> Session
+  TyreSet --> Car
+  TyreSet --> Driver
+  Incident --> Session
+  Incident --> Lap
+  Annotation --> Session
+  Annotation --> Lap
+```
+
+## Attributes & invariants
+- **Team**: `id`, `name`, `primaryColor`, `secondaryColor`. *Invariant*: name unique per deployment.
+- **User**: `id`, `teamId`, `email`, `role` (`engineer`, `strategist`, `viewer`). *Invariant*: `(teamId, email)` unique; role constrained to allow lists.
+- **Driver**: `id`, `teamId`, `code`, `fullName`, `country`. *Invariant*: `code` unique per team; drivers archived rather than deleted.
+- **Car**: `id`, `teamId`, `identifier` (e.g., 63), `chassis`, `powerUnit`. *Invariant*: identifier unique within team per season.
+- **Track**: `id`, `name`, `country`, `layoutVersion`, `lengthKm`, `turnCount`, `timezone`. *Invariant*: `(name, layoutVersion)` unique.
+- **Event**: `id`, `trackId`, `season`, `round`, `name`, `startDate`, `endDate`. *Invariant*: `(season, round)` unique; `startDate <= endDate`.
+- **Session**: `id`, `eventId`, `kind` (`FP1`, `Quali`, `Race`, etc.), `status`, `scheduledStart`, `scheduledEnd`, `actualStart`, `actualEnd`. *Invariant*: `kind` valid for FIA calendar; actual times within event range.
+- **Stint**: `id`, `sessionId`, `carId`, `driverId`, `tyreSetId`, `startLap`, `endLap`, `compound`, `fuelStartKg`, `fuelEndKg`. *Invariant*: `startLap <= endLap`; stints for same car cannot overlap laps.
+- **Lap**: `id`, `sessionId`, `carId`, `lapNumber`, `driverId`, `timeMs`, `isInLap`, `isOutLap`, `isPitLap`, `sector1Ms`, `sector2Ms`, `sector3Ms`, `trackStatus`. *Invariant*: lap numbers contiguous per session+car; sector sums within ±10ms of `timeMs`.
+- **TelemetrySample**: `id`, `sessionId`, `carId`, `driverId`, `lapId?`, `timestamp`, `speedKph`, `throttlePct`, `brakePct`, `rpm`, `gear`, `steerDeg`, `tyreTemps`, `brakeTemps`, `rideHeight`, `batteryState`. *Invariant*: timestamps monotonic per car; throttle/brake 0–100; gear in allowed set.
+- **SetupSheet**: `id`, `sessionId`, `carId`, `baselineVersion`, `wingAngle`, `rideHeight`, `camber`, `toe`, `suspension`, `notes`, `createdBy`. *Invariant*: one active baseline per session+car; values within engineering bounds (see appendix).
+- **WeatherSnapshot**: `id`, `sessionId`, `timestamp`, `airTempC`, `trackTempC`, `humidityPct`, `pressureHpa`, `windSpeedKph`, `windDirectionDeg`, `weatherCondition`. *Invariant*: timestamps align with telemetry sampling frequency.
+- **TyreSet**: `id`, `sessionId`, `carId`, `compound`, `ageLaps`, `isNew`, `serial`, `assignedAt`, `returnedAt?`. *Invariant*: `serial` unique per event; tyre set cannot be active in overlapping stints.
+- **Incident**: `id`, `sessionId`, `lapId?`, `timecode`, `flag`, `description`, `severity`. *Invariant*: `flag` from controlled vocabulary; severity used for alerting thresholds.
+- **Annotation**: `id`, `sessionId`, `lapId?`, `timecode`, `authorId`, `category`, `message`, `visibility`. *Invariant*: visibility in {team, car, personal}; author must belong to same team.
+
+## Derived views & aggregates
+- **Session summary**: per car, aggregate fastest lap, stint average pace, total pit time, tyre usage.
+- **Driver comparison**: aligned telemetry for two drivers (speed, throttle, brake, rpm, gear) with delta trace.
+- **Strategy view**: timeline of stints, tyre sets, fuel usage, weather overlays.
+- **Reliability dashboard**: aggregated alerts (engine temps, brake fade, ERS state) with thresholds and last-occurrence times.
+
+## Domain events
+- `SessionScheduled`, `SessionStarted`, `SessionPaused`, `SessionResumed`, `SessionCompleted`
+- `StintStarted`, `StintCompleted`
+- `LapCompleted`
+- `TelemetryIngested`
+- `IncidentLogged`
+- `AnnotationAdded`
+- `SetupUpdated`
+
+## Open questions
+1. Do we support multiple teams per deployment or assume single-team SaaS? Impacts auth scopes.
+2. How to model shared cars (e.g., endurance) where multiple drivers share same stint? Possibly allow `driverId` array per stint.
+3. Telemetry volume: do we store raw Hz-level data or downsample for analytics? Storage + query strategy open.
+4. Need to clarify integration with external timing providers for authoritative lap/sector data.
+
+## Next steps
+- Produce ERD diagram with finalized attributes (use Prisma schema once available).
+- Define API contracts in `docs/api/` for core operations (session list, telemetry fetch, annotations CRUD).
+- Establish validation schemas (Zod) for telemetry ingestion pipeline.
+- Align design tokens referenced in `docs/design-principles.md` with actual implementation in web layer.

--- a/docs/ux-principles.md
+++ b/docs/ux-principles.md
@@ -1,0 +1,41 @@
+# RC Race Engineer — UX Principles
+
+## 1) Glanceable under pressure
+- Large, high-contrast summaries with drill-down. Critical info must be readable from 1–2m distance.
+
+## 2) Consistency over cleverness
+- One visual grammar: same signal → same color/shape across the app.
+- Units explicit (metric default) and consistent everywhere.
+
+## 3) Time is the spine
+- Shared zoom/pan & synchronized cursors across charts.
+- Selecting lap/stint highlights across tables, charts, and map.
+
+## 4) Perceived performance
+- Skeletons over spinners; optimistic UI only for safe local edits.
+- Cache recent sessions and prefetch likely next views.
+
+## 5) Errors guide recovery
+- Errors state what failed, why, and how to fix; always offer a retry.
+- Errors don’t trap navigation.
+
+## 6) Accessibility
+- Keyboard navigable, visible focus states, WCAG AA contrast.
+- Never rely on color—pair with shape/label.
+
+## 7) Visualization
+- Prefer line/area charts; avoid 3D. Provide raw vs smoothed toggles.
+- Respect downsampling; show reference bands (e.g., target temps).
+
+## 8) Information architecture
+- Left nav: Sessions, Cars, Drivers, Tracks.
+- Status bar: health/ready/version + active session indicator.
+- Secondary panels: Annotations/alerts, Setups, Environment.
+
+## 9) Content & microcopy
+- Plain language; jargon needs a tooltip.
+- Consistent verbs; confirmations are brief and undoable where possible.
+
+## 10) Theming & motion
+- Light/dark modes with shared tokens (spacing, radii, typography).
+- Subtle motion only; respect reduced-motion settings.


### PR DESCRIPTION
## Summary
- replace the repository agent rules with detailed guidance covering branches, PR discipline, model updates, and module boundaries
- add design and UX principle documents that define the architectural north star, layering exceptions, visual grammar, and UX heuristics
- document the draft domain model with entities, relationships, invariants, and open questions for future refinement

## Testing
- not run (docs-only)

## Design compliance
- Aligns with [Design Principles §0 System shape](docs/design-principles.md#0-system-shape), §1 Contracts first, and §13 Visual grammar & tokens.
- Aligns with [UX Principles §1 Glanceable under pressure](docs/ux-principles.md#1-glanceable-under-pressure) and §2 Consistency over cleverness.

## Risk & Rollback
- Low risk documentation change. Revert via squash-merge rollback if needed.


------
https://chatgpt.com/codex/tasks/task_e_68ca9f799738832185d98e4d22ace4d2