### PR TITLE
Use design token font family in globals

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -22,5 +22,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans), system-ui, sans-serif;
 }


### PR DESCRIPTION
## Summary
- point the global body font-family to the design token-backed `--font-sans` variable so the UI defaults to Geist with system fallbacks

## Testing
- npm run dev (fails to fetch remote Geist assets in offline container; verified CSS variable resolves to `"Geist", "Geist Fallback"` in the browser)

## Design compliance
- Aligns typography with shared design tokens to keep the visual grammar consistent (`docs/design-principles.md` §13).

------
https://chatgpt.com/codex/tasks/task_e_68cb984106508321bc0503c3d9343337