### PR TITLE
fix: align create session action signature

### DIFF
--- a/web/src/app/actions.ts
+++ b/web/src/app/actions.ts
@@ -10,7 +10,10 @@ export interface ActionResult {
   issues?: string[];
 }
 
-export async function createSessionAction(formData: FormData): Promise<ActionResult> {
+export async function createSessionAction(
+  _prevState: ActionResult,
+  formData: FormData,
+): Promise<ActionResult> {
   const payload = {
     name: formData.get("name"),
     description: formData.get("description"),


### PR DESCRIPTION
## Summary
- align the createSessionAction signature with useFormState by accepting the previous state argument

## Testing
- npm run lint *(fails: missing dependency `@eslint/eslintrc` in lint config)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbdc5ae388321bb5ed2a763c62f73