### PR TITLE
feat: add heartbeat endpoints and session data foundation

### DIFF
--- a/web/src/app/actions.ts
+++ b/web/src/app/actions.ts
@@ -10,7 +10,10 @@ export interface ActionResult {
   issues?: string[];
 }
 
-export async function createSessionAction(formData: FormData): Promise<ActionResult> {
+export async function createSessionAction(
+  _prevState: ActionResult,
+  formData: FormData,
+): Promise<ActionResult> {
   const payload = {
     name: formData.get("name"),
     description: formData.get("description"),


### PR DESCRIPTION
## Summary
- add /api/health, /api/ready, and /api/version endpoints backed by system use-cases and Prisma readiness probe
- stand up Prisma schema, migration, and repository wiring for sessions plus in-repo stub client
- replace landing page with session control tower UI and document session/heartbeat API contracts
- align the create session server action signature with the useFormState contract to avoid runtime errors

## Testing
- npm run lint *(fails: ESLint cannot resolve @eslint/eslintrc when executing the flat config under the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbd9749508321ae513a20984059dd