### PR TITLE
docs: add build log for release tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # RC Race Engineer
 
 Fresh start. This repo contains the web app and related tooling for the RC Race Engineer project.
+
+## Build tracking
+Release and artifact builds are logged in [docs/build-log.md](docs/build-log.md). Update the log immediately after each successful release build so future maintainers can trace what was shipped and when.

--- a/docs/build-log.md
+++ b/docs/build-log.md
@@ -1,0 +1,13 @@
+# Build Log
+
+This log tracks release builds and documentation of generated artifacts. Keep it up to date so we can trace exactly what shipped and under which conditions.
+
+## Update workflow
+- **Who**: The engineer (human or agent) responsible for the build run updates this file before publishing artifacts.
+- **When**: Add a new entry immediately after a successful release build or when regenerating artifacts that ship to users.
+- **How**: Append a row to the table below with the UTC date, commit SHA, build environment summary, identifiers/URLs for any generated artifacts, and concise release notes.
+
+## History
+| Date (UTC) | Commit | Environment | Artifacts | Notes |
+| --- | --- | --- | --- | --- |
+| 2025-09-19 | e7a370c8 | Ubuntu 24.04.2 LTS container, Node v22.19.0 | _Seed entry – no artifacts generated_ | Seeded build log documentation for repository onboarding. |


### PR DESCRIPTION
## Summary
- add a build log in docs capturing release metadata and update workflow
- reference the new log from the README so contributors keep it current

## Testing
- not run (docs-only change)

## Design compliance
- Documentation-only change; no impact on system design or UX principles.

## Risk & Rollback
- Low risk; revert this commit to roll back the change.


------
https://chatgpt.com/codex/tasks/task_e_68cd63d61f7483219c2599b7d4444b96