### PR TITLE
docs: add LiveRC ingestion assumptions and goals

### DIFF
--- a/docs/codex/assumptions-and-goals.md
+++ b/docs/codex/assumptions-and-goals.md
@@ -1,0 +1,18 @@
+# Assumptions & Goals for LiveRC Ingestion and Analytics
+
+**Author:** Jayson + The Brainy One  
+**Date:** 2025-09-20  
+**License:** MIT
+
+## Assumptions
+
+- LiveRC does not present a single on-screen, multi-driver, lap-by-lap comparison table for a race; each driver’s laps open individually.
+
+## Goals
+
+1. **All My Laps at a Track (Ever):** Provide per-driver, cross-event lap history at a venue with flexible filters and summary statistics.
+2. **Multi-Driver Lap Comparison:** Offer a unified table organized by lap number, including lap deltas and highlighting the fastest driver per lap.
+
+## Implications
+
+- These two views are first-class experiences; ingestion pipelines and the data model must explicitly support them.


### PR DESCRIPTION
## Summary
- document LiveRC ingestion assumptions around current lap comparison capabilities
- capture goals for cross-event lap history and multi-driver lap comparison views
- note implications for ingestion pipelines and data model support

## Testing
- not run (documentation only)

## Design compliance
- Documentation-only change; maintains alignment with architectural and UX principles in `docs/design-principles.md` and `docs/ux-principles.md`.

## Risk & Rollback
- Low risk; revert commit if issues arise.

------
https://chatgpt.com/codex/tasks/task_e_68cd69d2721883219320bc21c0522f70