### PR TITLE
Add LiveRC ingestion specs and guidance

### DIFF
--- a/docs/codex/LiveRC-Metadata.md
+++ b/docs/codex/LiveRC-Metadata.md
@@ -1,0 +1,146 @@
+Title: LiveRC Metadata Specification
+Author: Jayson + The Brainy One
+Date: 2025-09-20
+Purpose: Canonical field-level spec for scraping/crawling LiveRC pages used by RCRE (events, rounds, heats/races, results, rankings, laps). Treat this as the single source of truth for names and semantics.
+License: MIT
+
+## Page Types (canonical slugs)
+- event: `?p=view_event&id=<eventId>` — event hub page
+- entry_list: `?p=view_entry_list&id=<eventId>` — per-class entries
+- heat_sheet: `?p=view_heat_sheet&id=<heatSheetId>` — practice/qual/main lineups
+- round_ranking: `?p=view_round_ranking&id=<roundId>&o=<mode>` — per-round overall rankings
+- race_result: `?p=view_race_result&id=<raceId>` — single race (qual/main) result summary + per-driver lap links
+- multi_main_result: `?p=view_multi_main_result&id=<multiMainId>` — A1/A2/A3 standings
+- event_overall_ranking: `?p=event_overall_ranking&id=<eventId>` — event/class final results
+
+> Selector strategy: Prefer stable, visible labels/column headers (e.g., “Laps/Time”, “Top 3 Consecutive”) and table structure. Avoid brittle CSS paths. Always persist sourceUrl, fetchedAt, and raw HTML in SourceCache with sha.
+
+## Common Vocabulary
+- Class: e.g., “1/8 Electric Buggy”, “1/8 Nitro Buggy”
+- Round: practice | qual | main + ordinal (e.g., 6 for Q6)
+- Heat/Race: specific on-track session within a round (e.g., Heat 4/4, A-Main, M1 Race #10)
+
+## event (view_event)
+Fields
+- event.id (string) — LiveRC event id
+- event.name (string)
+- event.trackName (string)
+- event.dateStart (ISO8601)
+- event.dateEnd (ISO8601)
+- event.stats.entries (int)
+- event.stats.drivers (int)
+- event.stats.totalLaps (int)
+- links.entryListUrl (url)
+- links.discovered[] (urls to entry_list, heat_sheet*, round_ranking, race_result, multi_main_result, event_overall_ranking)
+- sourceUrl (url)
+- fetchedAt (ISO8601)
+Example
+- event.id = "462466"
+- event.name = "2025 RCRA Campbelltown Hobbies ACT State Titles"
+- event.trackName = "Canberra Off Road Model Car Club"
+- dateStart = 2025-03-07, dateEnd = 2025-03-09
+
+## entry_list (view_entry_list)
+Fields
+- eventId
+- class.name
+- entries[]: { driver.name, transponder, carNumber? }
+- class.entryCount (int)
+- sourceUrl, fetchedAt
+Example
+- class.name = "1/8 Electric Buggy"
+- entries[i].driver = "JAYSON BRENTON"
+- entries[i].transponder = "8970568"
+
+## heat_sheet (view_heat_sheet)
+Fields
+- heatSheet.id (string)
+- eventId, class.name
+- round.type (practice|qual|main)
+- round.ordinal (int)
+- round.label (e.g., "Qualifier Round 6")
+- heat.name (e.g., "Heat 4/4", "A-Main", "Race #10")
+- heat.lengthSec (int; e.g., 300, 420, 600)
+- heat.timed (bool)
+- heat.status (string)
+- grid[]: { pos, carNumber, driver.name, transponder, seedNumber?, seedResultText? }
+- viewResultUrl (url?)
+- sourceUrl, fetchedAt
+Example
+- round.type="qual", round.ordinal=6, heat.name="Heat 4/4"
+- grid[0] = { pos:1, carNumber:3, driver:"ALEX BERNADZIK", transponder:"<id>" }
+
+## round_ranking (view_round_ranking)
+Fields
+- round.id, eventId, class.name
+- round.type="qual"
+- round.ordinal (int)
+- rankMode (enum): laps_time | top2 | top3 | top5 | avg | fastest
+- rows[]: { rank, driver.name, transponder?, laps, timeMs, top2Ms?, top3Ms?, top5AvgMs?, fastestLapMs?, avgLapMs?, heatRef }
+- sourceUrl, fetchedAt
+Example
+- rank=1, driver="ALEX BERNADZIK", laps=12, timeMs=448821 (7:28.821)
+
+## race_result (view_race_result)
+Fields
+- race.id (string), eventId, class.name
+- round.type (practice|qual|main), round.ordinal (int)
+- heat.name
+- lengthSec (int)
+- raceNumberLabel (e.g., "M1 Race #10", "Q6 Race #7")
+- results[] per driver:
+  { pos, qualified?, laps, totalTimeMs, behindText, fastestLapMs, fastestLapNo, avgLapMs, avgTop5Ms, avgTop10Ms, avgTop15Ms, top3ConsecMs, stdDevMs, consistencyPct, viewLapsUrl }
+- sourceUrl, fetchedAt
+Examples
+- Main winner: pos=1, laps=73, totalTimeMs≈2716678, fastestLapMs≈35670, consistencyPct≈93.11
+- Qual winner: pos=1, laps=11, totalTimeMs≈449642, fastestLapMs≈39554, consistencyPct≈98.27
+
+## multi_main_result (view_multi_main_result)
+Fields
+- multiMain.id, eventId, class.name
+- tieBreaker (e.g., IFMAR)
+- rows[]:
+  { driver.name, qualifiedPos, pointsTotal, legs: { A1:{place,points,laps,timeMs}, A2:{...}, A3:{...} } }
+- sourceUrl, fetchedAt
+Example
+- driver="ALEX BERNADZIK", pointsTotal=2, A1.place=1, A3.place=1
+
+## event_overall_ranking (event_overall_ranking)
+Fields
+- eventId, class.name
+- rows[]: { pos, driver.name, resultLaps, resultTimeMs, mainRef?, brand?, country? }
+- sourceUrl, fetchedAt
+Example
+- pos=1, driver="ALEX BERNADZIK", resultLaps=17, resultTimeMs≈613929, mainRef="A"
+
+## Lap detail (via per-driver “View Laps”)
+Fields
+- race.id, driver.name, driver.transponder
+- laps[]: { lapNo, lapTimeMs, pit?, invalid? }
+- sourceUrl, fetchedAt
+Example
+- laps[1].lapTimeMs≈37014; laps[7].lapTimeMs≈40250
+
+## Cross-cutting Requirements
+- Persist SourceCache { id, url, fetchedAt, status, sha, body } for every fetch
+- Idempotency keys:
+  - Event: id
+  - Class: (eventId, name)
+  - Round: (eventId, classId, type, ordinal)
+  - Heat/Race: id
+  - Participant: (heatId, driverId)
+  - RaceResult: (heatId, driverId)
+  - Lap: (heatId, driverId, lapNo)
+  - RoundRanking: (roundId, classId, driverId, rankMode)
+  - MultiMainStanding: (eventId, classId, driverId)
+  - EventOverallResult: (eventId, classId, driverId)
+- Telemetry events:
+  - import_job_started/completed/failed
+  - page_fetch_started/completed (url, ms, status, cacheHit)
+  - parse_started/completed (pageType, rows)
+  - laps_imported_count, records_upserted_count
+- Performance notes:
+  - Parser should process typical pages < 150 ms each on cached HTML
+  - Avoid blocking UI; long operations run as background jobs with progress logs
+
+---

--- a/docs/codex/RCRE-Features-Prompt.md
+++ b/docs/codex/RCRE-Features-Prompt.md
@@ -1,0 +1,10 @@
+# RCRE Features Prompt
+
+## Level 1 / Level 2 (Implementation contract)
+
+When ingesting or analysing LiveRC data, follow:
+- docs/codex/LiveRC-Metadata.md
+- docs/codex/ingestion-plan.md
+- docs/codex/model-extensions.md
+
+Honour performance budgets (UI P50 ≤ 300 ms, P95 ≤ 800 ms; API reads P95 ≤ 400 ms) and emit telemetry for timings, errors, and event counts. Treat these docs as the single source of truth for field names, idempotency keys, and crawl order.

--- a/docs/codex/ingestion-plan.md
+++ b/docs/codex/ingestion-plan.md
@@ -1,0 +1,57 @@
+Title: LiveRC Ingestion Plan (Crawler + Importers)
+Author: Jayson + The Brainy One
+Date: 2025-09-20
+Purpose: Define the import workflow that turns a single LiveRC event URL into normalized RCRE data with caching, idempotency and telemetry.
+License: MIT
+
+## Inputs
+- eventUrl (required) — LiveRC view_event URL
+- Filters (optional): classes[], roundTypes[] (practice|qual|main), roundOrdinals[] (ints)
+- Flags: force (bypass cache), dryRun (no writes), maxConcurrency (default 4), politenessDelayMs (default 500)
+
+## Outputs (upserts)
+Event, Track, Class, Round, Heat, Participant, RaceResult, Lap, RoundRanking, MultiMainStanding, EventOverallResult, SourceCache
+
+## Crawl Order
+1. Fetch eventUrl → parse Event + discover links to entry_list, all heat_sheet pages (practice/qual/main), round_ranking, race_result (from “View Results”/index pages), multi_main_result, event_overall_ranking.
+2. For each discovered page:
+   - Check SourceCache by URL sha; skip parse if unchanged (unless --force).
+   - Parse per LiveRC-Metadata.md; stage normalized records.
+3. For each race_result page:
+   - Upsert results[] per driver.
+   - For each result row, follow viewLapsUrl; parse laps[]; upsert Lap by (heatId, driverId, lapNo).
+4. Linkages:
+   - Map drivers by (name, transponder) to Driver.id.
+   - Resolve Track from event.trackName (create if missing).
+   - Maintain Class, Round(type+ordinal), Heat ids.
+
+## Idempotency & Keys
+- Use the keys defined in LiveRC-Metadata.md (Cross-cutting Requirements).
+- Upsert semantics: insert new, update if changed (by sha or field diff).
+- Ensure stable race.id/heatSheet.id derivation.
+
+## Caching
+- SourceCache { url, fetchedAt, status, sha, body } must be written for every fetch.
+- Cache policy: skip unchanged html by sha unless --force.
+- Store minimal body (trimmed) but sufficient for re-parse.
+
+## Telemetry
+- Events: import_job_started/completed/failed; page_fetch_started/completed; parse_started/completed; records_upserted_count; laps_imported_count.
+- Timings: capture ms per fetch, per parse, overall job duration.
+- IDs: anonymised session/user IDs where applicable.
+
+## Error Handling
+- Retries: 3 with exponential backoff on transient network errors.
+- Partial progress: continue other pages if one fails; report failures at end.
+- Validation: reject records missing required ids (e.g., eventId, raceId).
+
+## Performance Targets
+- P95 setup for import API ≤ 400 ms (job kickoff); background job runs to completion.
+- Steady-state parse throughput: ≥ 20 pages/minute with concurrency=4 on cached HTML.
+
+## Interfaces
+- API: POST /api/import/liverc { eventUrl, filters, flags }
+- CLI: scripts/import-liverc --event <url> [--class "..."] [--type qual] [--force] [--dry-run]
+- UI (later): import wizard with progress log and summary counts.
+
+---

--- a/docs/codex/model-extensions.md
+++ b/docs/codex/model-extensions.md
@@ -1,0 +1,188 @@
+Title: Model Extensions for LiveRC Ingestion
+Author: Jayson + The Brainy One
+Date: 2025-09-20
+Purpose: Target schema contract Codex will translate into Prisma models/migrations and API DTOs.
+License: MIT
+
+## Entities (fields are indicative; Codex will map to Prisma types)
+Event
+- id (string, pk)
+- name (string)
+- trackId (fk Track.id)
+- startsAt (datetime)
+- endsAt (datetime)
+- statsEntries (int)
+- statsDrivers (int)
+- statsTotalLaps (int)
+- sourceUrl (string)
+- createdAt (datetime, default now)
+
+Track
+- id (string, pk)
+- name (string)
+- city (string?)
+- country (string?)
+- surface (string?)
+- providerSlug (string?)
+- createdAt (datetime)
+
+Class
+- id (string, pk)
+- eventId (fk)
+- name (string)
+- createdAt (datetime)
+- UNIQUE (eventId, name)
+
+Round
+- id (string, pk)
+- eventId (fk)
+- classId (fk)
+- type (enum: practice | qual | main)
+- ordinal (int)
+- label (string)
+- sourceUrl (string)
+- createdAt (datetime)
+- UNIQUE (eventId, classId, type, ordinal)
+
+Heat  // aka Race
+- id (string, pk)           // LiveRC race/heat id
+- roundId (fk)
+- classId (fk)
+- name (string)             // e.g., "Heat 4/4", "A-Main", "Race #10"
+- lengthSec (int)
+- timed (bool)
+- status (string)
+- startedAt (datetime?)
+- completedAt (datetime?)
+- seedNumber (int?)
+- seedTotal (int?)
+- seedResultText (string?)
+- sourceUrl (string)
+- createdAt (datetime)
+
+Participant
+- id (string, pk)
+- heatId (fk)
+- driverId (fk)
+- carNumber (int?)
+- gridPos (int?)
+- transponder (string)
+- seedNumber (int?)
+- createdAt (datetime)
+- UNIQUE (heatId, driverId)
+
+Driver
+- id (string, pk)
+- name (string)
+- transponder (string)      // nullable allowed but UNIQUE on (name, transponder) when present
+- avatarUrl (string?)
+- createdAt (datetime)
+- UNIQUE (name, transponder)
+
+RaceResult  // per driver per race summary
+- id (string, pk)
+- heatId (fk)
+- driverId (fk)
+- position (int)
+- qualified (int?)          // grid spot
+- laps (int)
+- totalTimeMs (int)
+- behindText (string)       // “+1 lap” or “+00:03.215”
+- fastestLapMs (int)
+- fastestLapNo (int)
+- avgLapMs (int)
+- avgTop5Ms (int?)
+- avgTop10Ms (int?)
+- avgTop15Ms (int?)
+- top3ConsecMs (int?)
+- stdDevMs (int?)
+- consistencyPct (float?)   // 0..100
+- sourceUrl (string)
+- createdAt (datetime)
+- UNIQUE (heatId, driverId)
+
+Lap
+- id (string, pk)
+- heatId (fk)
+- driverId (fk)
+- lapNo (int)
+- lapTimeMs (int)
+- pit (bool)
+- invalid (bool)
+- createdAt (datetime)
+- UNIQUE (heatId, driverId, lapNo)
+
+RoundRanking
+- id (string, pk)
+- roundId (fk)
+- classId (fk)
+- driverId (fk)
+- rankMode (enum: laps_time | top2 | top3 | top5 | avg | fastest)
+- rankPosition (int)
+- laps (int)
+- timeMs (int)
+- top2ConsecMs (int?)
+- top3ConsecMs (int?)
+- top5AvgMs (int?)
+- fastestLapMs (int?)
+- avgLapMs (int?)
+- heatRef (string?)
+- createdAt (datetime)
+- UNIQUE (roundId, classId, driverId, rankMode)
+
+MultiMainStanding
+- id (string, pk)
+- eventId (fk)
+- classId (fk)
+- driverId (fk)
+- tieBreaker (string)
+- legsCompleted (int)
+- pointsTotal (int)
+- A1_place (int?)  A1_points (int?)  A1_laps (int?)  A1_timeMs (int?)
+- A2_place (int?)  A2_points (int?)  A2_laps (int?)  A2_timeMs (int?)
+- A3_place (int?)  A3_points (int?)  A3_laps (int?)  A3_timeMs (int?)
+- createdAt (datetime)
+- UNIQUE (eventId, classId, driverId)
+
+EventOverallResult
+- id (string, pk)
+- eventId (fk)
+- classId (fk)
+- driverId (fk)
+- resultLaps (int)
+- resultTimeMs (int)
+- mainRef (string?)
+- brand (string?)
+- country (string?)
+- createdAt (datetime)
+- UNIQUE (eventId, classId, driverId)
+
+SourceCache
+- id (string, pk)
+- url (string)
+- fetchedAt (datetime)
+- status (int)
+- sha (string)
+- body (text)
+- createdAt (datetime)
+- UNIQUE (url, sha)
+
+## Indexes (recommended)
+- Heat: index (classId, roundId), (name), (startedAt)
+- RaceResult: index (heatId), (driverId)
+- Lap: index (heatId, driverId, lapNo)
+- RoundRanking: index (roundId, classId, rankMode, rankPosition)
+
+## Relationships
+- Event 1-N Class, Round
+- Round 1-N Heat
+- Heat 1-N Participant, RaceResult, Lap
+- Driver 1-N Participant, RaceResult, Lap
+- Class 1-N Round, Heat
+- Event 1-N RoundRanking, MultiMainStanding, EventOverallResult (via Class)
+
+## Migration Notes
+- Generate Prisma migration; add foreign keys and unique constraints exactly as above.
+- Add seed script to create Track from event.trackName if missing.
+
+---


### PR DESCRIPTION
## Summary
- add canonical LiveRC metadata specification for crawler fields and semantics
- document ingestion workflow, caching, idempotency, telemetry, and performance targets
- capture target data model extensions and update features prompt with ingestion guidance

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68cd6c5e8d5c832180c8aa8756f71328