### PR TITLE
Add database sync script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ Release and artifact builds are logged in [docs/build-log.md](docs/build-log.md)
 
 Fresh start. This repo contains the web app and related tooling for The RC Racing Engineer project.
 
+## Database synchronisation
+
+Use `scripts/db-sync.sh` to keep the local database schema in sync with the Prisma migrations. The script runs `prisma generate` and `prisma migrate deploy` from the `web` workspace, then checks `http://localhost:3000/api/ready` (or the `READY_ENDPOINT` environment override). It exits non-zero if any step fails, which makes it safe to wire into deployment hooks or CI jobs.
+

--- a/scripts/db-sync.sh
+++ b/scripts/db-sync.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+READY_ENDPOINT="${READY_ENDPOINT:-http://localhost:3000/api/ready}"
+
+(
+  cd "$ROOT_DIR/web"
+  npx prisma generate
+  npx prisma migrate deploy
+)
+
+curl --fail --silent --show-error "$READY_ENDPOINT" >/dev/null


### PR DESCRIPTION
## Summary
- add `scripts/db-sync.sh` to run Prisma generate/deploy and verify the `/api/ready` endpoint
- document the database sync helper in the README for operators

## Design compliance
- Aligns with [Design Principle 8 — Observability](docs/design-principles.md#8-observability) by checking the ready endpoint before reporting success.

## Testing
- Not run (script-only change)

## Risk & Rollback
- Low risk; revert this commit to roll back.


------
https://chatgpt.com/codex/tasks/task_e_68cd71d62ef08321835b3dd24a017474