### PR TITLE
docs: add module headers and inline guidance

### DIFF
--- a/web/src/app/api/sessions/route.ts
+++ b/web/src/app/api/sessions/route.ts
@@ -1,3 +1,13 @@
+/**
+ * File: web/src/app/api/sessions/route.ts
+ * Purpose: Implements the REST surface for listing and creating sessions. This
+ *          route wires the application layer use-cases to the Next.js API
+ *          runtime and ensures that the infra bootstrap executes before
+ *          handling requests.
+ * Notes:  We return structured JSON for both success and error cases so the
+ *          front-end can present meaningful feedback without parsing strings.
+ */
+
 import { NextResponse } from "next/server";
 import "@/server/bootstrap";
 import { listSessions } from "@/core/app/sessions/listSessions";
@@ -5,6 +15,8 @@ import { createSession } from "@/core/app/sessions/createSession";
 
 export async function GET() {
   try {
+    // The use-case abstracts persistence, so the handler simply forwards the
+    // result to the caller.
     const sessions = await listSessions();
     return NextResponse.json({ sessions });
   } catch (error) {
@@ -18,10 +30,14 @@ export async function POST(request: Request) {
   try {
     payload = await request.json();
   } catch {
+    // Provide an explicit message when the client sends malformed JSON, which
+    // helps them troubleshoot without digging into logs.
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
   try {
+    // Validation occurs inside the use-case so we can surface consistent error
+    // structures from a single location.
     const session = await createSession(payload);
     return NextResponse.json({ session }, { status: 201 });
   } catch (error) {

--- a/web/src/core/app/sessions/createSession.ts
+++ b/web/src/core/app/sessions/createSession.ts
@@ -1,3 +1,10 @@
+/**
+ * File: web/src/core/app/sessions/createSession.ts
+ * Purpose: Coordinates validation and persistence for new sessions. It
+ *          transforms validation errors into a format the API layer can surface
+ *          and delegates storage to the registered repository implementation.
+ */
+
 import { InvalidSessionInputError, validateCreateSessionInput } from "@/core/domain/session";
 import type { Session } from "@/core/domain/session";
 import type { SessionDependencies } from "./ports";
@@ -6,6 +13,9 @@ import { getSessionRepository } from "./serviceLocator";
 export async function createSession(payload: unknown, deps?: Partial<SessionDependencies>): Promise<Session> {
   let input: ReturnType<typeof validateCreateSessionInput>;
   try {
+    // Validation resides in the domain layer to keep rules close to the core
+    // types. We capture and rethrow domain validation errors with metadata so
+    // transport layers can render structured feedback.
     input = validateCreateSessionInput(payload);
   } catch (error: unknown) {
     if (error instanceof InvalidSessionInputError) {
@@ -14,10 +24,14 @@ export async function createSession(payload: unknown, deps?: Partial<SessionDepe
     throw error;
   }
 
+  // Support dependency injection for tests while defaulting to the globally
+  // registered repository resolved during bootstrap.
   const { repository } = deps ?? { repository: getSessionRepository() };
   if (!repository) {
     throw new Error("Session repository dependency missing");
   }
 
+  // Persist the validated session and return the enriched representation from
+  // the repository (which may hydrate LiveRC metadata).
   return repository.create(input);
 }

--- a/web/src/core/app/sessions/listSessions.ts
+++ b/web/src/core/app/sessions/listSessions.ts
@@ -1,11 +1,22 @@
+/**
+ * File: web/src/core/app/sessions/listSessions.ts
+ * Purpose: Application use-case responsible for retrieving the most recent
+ *          sessions. The function enforces dependency availability and shields
+ *          the API layer from the underlying persistence implementation.
+ */
+
 import type { Session } from "@/core/domain/session";
 import type { SessionDependencies } from "./ports";
 import { getSessionRepository } from "./serviceLocator";
 
 export async function listSessions(deps?: Partial<SessionDependencies>): Promise<Session[]> {
+  // Allow tests to supply a stub repository while defaulting to the registered
+  // Prisma-backed implementation in production code paths.
   const { repository } = deps ?? { repository: getSessionRepository() };
   if (!repository) {
     throw new Error("Session repository dependency missing");
   }
+  // The repository encapsulates ordering and inclusion logic, so the use-case
+  // simply returns the collection.
   return repository.list();
 }

--- a/web/src/core/app/sessions/ports.ts
+++ b/web/src/core/app/sessions/ports.ts
@@ -1,7 +1,16 @@
+/**
+ * File: web/src/core/app/sessions/ports.ts
+ * Purpose: Declares the contracts that infrastructure adapters must implement
+ *          to satisfy the session application use-cases.
+ */
+
 import type { CreateSessionInput, Session } from "@/core/domain/session";
 
 export interface SessionRepository {
+  // Persist a new session and return the hydrated representation used by the
+  // rest of the application.
   create(data: CreateSessionInput): Promise<Session>;
+  // Retrieve a slice of sessions, typically the most recent records.
   list(): Promise<Session[]>;
 }
 

--- a/web/src/core/app/sessions/serviceLocator.ts
+++ b/web/src/core/app/sessions/serviceLocator.ts
@@ -1,8 +1,18 @@
+/**
+ * File: web/src/core/app/sessions/serviceLocator.ts
+ * Purpose: Maintains the session repository instance used by the application
+ *          layer. The service locator pattern gives infra adapters a place to
+ *          register concrete implementations without leaking them to domain
+ *          modules.
+ */
+
 import type { SessionRepository } from "./ports";
 
 let repository: SessionRepository | null = null;
 
 export function registerSessionRepository(instance: SessionRepository) {
+  // Called during server bootstrap to make the Prisma-backed repository
+  // available to use-cases.
   repository = instance;
 }
 
@@ -10,5 +20,7 @@ export function getSessionRepository(): SessionRepository {
   if (!repository) {
     throw new Error("Session repository has not been registered");
   }
+  // Returning the concrete repository keeps application code decoupled from
+  // the instantiation details.
   return repository;
 }

--- a/web/src/core/domain/session.ts
+++ b/web/src/core/domain/session.ts
@@ -1,3 +1,12 @@
+/**
+ * File: web/src/core/domain/session.ts
+ * Purpose: Defines the canonical session domain model, including enumerations
+ *          for session attributes, validation helpers, and the core input
+ *          validation routine used by the application layer.
+ * Notes:  Domain modules remain free of IO and framework concerns so that
+ *          validation logic can be tested and reused across adapters.
+ */
+
 export const SESSION_KINDS = [
   "FP1",
   "FP2",
@@ -178,6 +187,12 @@ export function validateCreateSessionInput(payload: unknown): CreateSessionInput
   };
 }
 
+/**
+ * Normalises a value into an ISO timestamp string while recording helpful error
+ * messages that can be surfaced to API consumers. Returning `null` for invalid
+ * input keeps the validation flow linear without additional branching in the
+ * caller.
+ */
 function coerceIsoDate(value: unknown, field: string, issues: string[]): string | null {
   if (value == null || value === "") {
     return null;

--- a/web/src/core/infra/db/prismaClient.ts
+++ b/web/src/core/infra/db/prismaClient.ts
@@ -1,10 +1,27 @@
+/**
+ * File: web/src/core/infra/db/prismaClient.ts
+ * Purpose: Centralises creation of the Prisma client while providing a single
+ *          cached instance during development to avoid exhausting database
+ *          connections. This module is imported by infra adapters that need
+ *          database access.
+ * Notes:  The caching pattern mirrors the recommendation from Prisma for
+ *          serverless-like environments where hot reloading could instantiate
+ *          multiple clients. We deliberately keep logging verbose in
+ *          development to aid query analysis.
+ */
+
 import type { Prisma } from "@prisma/client";
 import { PrismaClient } from "@prisma/client";
 
+// The global namespace is leveraged to persist the Prisma client across
+// repeated imports when Next.js performs hot module replacement.
 const globalForPrisma = globalThis as unknown as {
   prisma?: PrismaClient;
 };
 
+// Instantiate a single Prisma client. In development we elevate logging to
+// include queries, warnings, and errors so that developers can observe the SQL
+// being executed without additional tooling.
 export const prisma: PrismaClient =
   globalForPrisma.prisma ??
   new PrismaClient({
@@ -12,5 +29,8 @@ export const prisma: PrismaClient =
   } satisfies Prisma.PrismaClientOptions);
 
 if (process.env.NODE_ENV !== "production") {
+  // Persist the client on the global object so subsequent imports reuse the
+  // same instance. Production environments should prefer short-lived clients
+  // per request, so we skip caching there.
   globalForPrisma.prisma = prisma;
 }

--- a/web/src/core/infra/sessions/prismaSessionRepository.test.ts
+++ b/web/src/core/infra/sessions/prismaSessionRepository.test.ts
@@ -1,3 +1,10 @@
+/**
+ * File: web/src/core/infra/sessions/prismaSessionRepository.test.ts
+ * Purpose: Validates the mapping logic inside the Prisma session repository to
+ *          ensure LiveRC relationships are translated into the domain shape as
+ *          expected.
+ */
+
 import "../../../../test/setupAlias";
 import assert from "node:assert/strict";
 import test from "node:test";

--- a/web/src/core/infra/system/prismaHealthIndicator.ts
+++ b/web/src/core/infra/system/prismaHealthIndicator.ts
@@ -1,3 +1,9 @@
+/**
+ * File: web/src/core/infra/system/prismaHealthIndicator.ts
+ * Purpose: Registers a Prisma-backed readiness probe that verifies database
+ *          connectivity for the health endpoints.
+ */
+
 import { performance } from "node:perf_hooks";
 import { prisma } from "@/core/infra/db/prismaClient";
 import type { ReadinessProbeResult } from "@/core/app/system/ports";
@@ -6,6 +12,8 @@ import { registerReadinessDependencies } from "@/core/app/system/serviceLocator"
 export async function databaseProbe(): Promise<ReadinessProbeResult> {
   const started = performance.now();
   try {
+    // A lightweight `SELECT 1` ensures connectivity without impacting
+    // production traffic or requiring table-level access.
     await prisma.$queryRaw`SELECT 1`;
     return {
       name: "database",
@@ -17,11 +25,15 @@ export async function databaseProbe(): Promise<ReadinessProbeResult> {
       name: "database",
       healthy: false,
       durationMs: performance.now() - started,
+      // Surface the underlying error message when available so operators have a
+      // head start on diagnosing outages.
       details: error instanceof Error ? error.message : "Database probe failed",
     };
   }
 }
 
+// Register the probe so health endpoints can fan it out alongside any future
+// diagnostics.
 registerReadinessDependencies({
   probes: [databaseProbe],
 });

--- a/web/src/server/bootstrap.ts
+++ b/web/src/server/bootstrap.ts
@@ -1,3 +1,11 @@
+/**
+ * File: web/src/server/bootstrap.ts
+ * Purpose: Server-only entry point responsible for wiring infrastructure
+ *          adapters into the application layer service locators.
+ * Notes:  Import this module from API routes or server actions to ensure the
+ *          Prisma-backed adapters are registered before handling requests.
+ */
+
 "use server";
 
 import "@/core/infra/sessions/prismaSessionRepository";


### PR DESCRIPTION
## Summary
- add module-level header comments across session-related infrastructure and application files to improve context
- expand inline comments documenting dependency wiring, validation flow, and health probes for maintainability
- document server bootstrap responsibilities to reinforce layering expectations

## Testing
- ⚠️ `npm install` *(fails: registry access returns 403 in container; unable to install dependencies to run lint/tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7347d57883219b2ce3df3184904e