### PR TITLE
test: add API route coverage for sessions and events

### DIFF
--- a/web/test/api-session-events-route.test.ts
+++ b/web/test/api-session-events-route.test.ts
@@ -1,0 +1,265 @@
+import "./setupAlias";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { Session } from "@/core/domain/session";
+import type { TelemetrySample } from "@/core/domain/telemetry";
+import type { SessionRepository } from "@/core/app/sessions/ports";
+import type { TelemetryRepository } from "@/core/app/telemetry/ports";
+import { registerSessionRepository } from "@/core/app/sessions/serviceLocator";
+import { registerTelemetryRepository } from "@/core/app/telemetry/serviceLocator";
+import { GET, POST } from "@/app/api/sessions/[sessionId]/events/route";
+
+const baseSession: Session = {
+  id: "session-1",
+  name: "Evening practice",
+  description: null,
+  kind: "RACE",
+  status: "SCHEDULED",
+  scheduledStart: null,
+  scheduledEnd: null,
+  actualStart: null,
+  actualEnd: null,
+  timingProvider: "MANUAL",
+  liveRc: null,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+const baseSample: TelemetrySample = {
+  id: "sample-1",
+  sessionId: baseSession.id,
+  recordedAt: "2024-01-01T00:00:00.000Z",
+  speedKph: 120,
+  throttlePct: 80,
+  brakePct: 0,
+  rpm: 15000,
+  gear: 5,
+  createdAt: "2024-01-01T00:00:01.000Z",
+};
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return { ...baseSession, ...overrides };
+}
+
+function makeSample(overrides: Partial<TelemetrySample> = {}): TelemetrySample {
+  return { ...baseSample, ...overrides };
+}
+
+function registerSessionStub(overrides: Partial<SessionRepository> = {}) {
+  const repository: SessionRepository = {
+    async list() {
+      return [];
+    },
+    async create() {
+      throw new Error("not implemented");
+    },
+    async getById(id: string) {
+      return makeSession({ id });
+    },
+    ...overrides,
+  };
+
+  registerSessionRepository(repository);
+  return repository;
+}
+
+function registerTelemetryStub(overrides: Partial<TelemetryRepository> = {}) {
+  const repository: TelemetryRepository = {
+    async listForSession(sessionId) {
+      return [makeSample({ sessionId })];
+    },
+    async createForSession(sessionId, data) {
+      return makeSample({
+        sessionId,
+        recordedAt: data.recordedAt,
+        speedKph: data.speedKph ?? baseSample.speedKph,
+        throttlePct: data.throttlePct ?? baseSample.throttlePct,
+        brakePct: data.brakePct ?? baseSample.brakePct,
+        rpm: data.rpm ?? baseSample.rpm,
+        gear: data.gear ?? baseSample.gear,
+      });
+    },
+    ...overrides,
+  };
+
+  registerTelemetryRepository(repository);
+  return repository;
+}
+
+test("GET /api/sessions/:id/events returns session telemetry", async () => {
+  const session = makeSession({ id: "session-a", name: "Qualifier" });
+  const sample = makeSample({ sessionId: session.id, recordedAt: "2024-05-04T12:00:00.000Z" });
+
+  registerSessionStub({
+    async getById() {
+      return session;
+    },
+  });
+  registerTelemetryStub({
+    async listForSession(sessionId, options) {
+      assert.equal(options?.limit, 2);
+      assert.equal(options?.order, "asc");
+      return [sample];
+    },
+  });
+
+  const request = new Request(`http://localhost/api/sessions/${session.id}/events?limit=2`);
+  const response = await GET(request, { params: { sessionId: session.id } });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { session, samples: [sample] });
+});
+
+test("GET /api/sessions/:id/events validates limit query", async () => {
+  registerSessionStub();
+  registerTelemetryStub();
+
+  const request = new Request("http://localhost/api/sessions/session-1/events?limit=-3");
+  const response = await GET(request, { params: { sessionId: "session-1" } });
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), { error: "limit must be a positive number" });
+});
+
+test("GET /api/sessions/:id/events returns 404 when session missing", async () => {
+  registerSessionStub({
+    async getById() {
+      return null;
+    },
+  });
+  registerTelemetryStub();
+
+  const request = new Request("http://localhost/api/sessions/missing/events");
+  const response = await GET(request, { params: { sessionId: "missing" } });
+
+  assert.equal(response.status, 404);
+  assert.deepEqual(await response.json(), { error: "Session not found" });
+});
+
+test("GET /api/sessions/:id/events returns 500 when repository fails", async () => {
+  registerSessionStub({
+    async getById() {
+      return makeSession();
+    },
+  });
+  registerTelemetryStub({
+    async listForSession() {
+      throw new Error("query failed");
+    },
+  });
+
+  const request = new Request("http://localhost/api/sessions/session-1/events");
+  const response = await GET(request, { params: { sessionId: "session-1" } });
+
+  assert.equal(response.status, 500);
+  assert.deepEqual(await response.json(), { error: "Unable to load telemetry" });
+});
+
+test("POST /api/sessions/:id/events persists telemetry events", async () => {
+  const session = makeSession({ id: "session-z" });
+  const created = makeSample({ sessionId: session.id, recordedAt: "2024-06-01T10:00:00.000Z" });
+
+  registerSessionStub({
+    async getById() {
+      return session;
+    },
+  });
+  registerTelemetryStub({
+    async createForSession(sessionId, data) {
+      assert.equal(sessionId, session.id);
+      return makeSample({ ...created, recordedAt: data.recordedAt });
+    },
+  });
+
+  const request = new Request(`http://localhost/api/sessions/${session.id}/events`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ recordedAt: created.recordedAt, speedKph: 130 }),
+  });
+
+  const response = await POST(request, { params: { sessionId: session.id } });
+
+  assert.equal(response.status, 201);
+  assert.deepEqual(await response.json(), { sample: created });
+});
+
+test("POST /api/sessions/:id/events rejects malformed JSON", async () => {
+  registerSessionStub();
+  registerTelemetryStub();
+
+  const request = new Request("http://localhost/api/sessions/session-1/events", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "{broken",
+  });
+
+  const response = await POST(request, { params: { sessionId: "session-1" } });
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), { error: "Invalid JSON body" });
+});
+
+test("POST /api/sessions/:id/events returns 404 when session missing", async () => {
+  registerSessionStub({
+    async getById() {
+      return null;
+    },
+  });
+  registerTelemetryStub();
+
+  const request = new Request("http://localhost/api/sessions/absent/events", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ recordedAt: "2024-01-01T00:00:00.000Z" }),
+  });
+
+  const response = await POST(request, { params: { sessionId: "absent" } });
+
+  assert.equal(response.status, 404);
+  assert.deepEqual(await response.json(), { error: "Session not found" });
+});
+
+test("POST /api/sessions/:id/events surfaces validation errors", async () => {
+  registerSessionStub();
+  registerTelemetryStub();
+
+  const request = new Request("http://localhost/api/sessions/session-1/events", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ speedKph: -5 }),
+  });
+
+  const response = await POST(request, { params: { sessionId: "session-1" } });
+
+  assert.equal(response.status, 400);
+  const body = await response.json();
+  assert.equal(body.error, "Validation failed");
+  assert.ok(Array.isArray(body.issues));
+  assert.ok(body.issues.includes("speedKph must be >= 0"));
+  assert.ok(body.issues.includes("Invalid input"));
+});
+
+test("POST /api/sessions/:id/events returns 500 when persistence fails", async () => {
+  registerSessionStub({
+    async getById() {
+      return makeSession({ id: "session-1" });
+    },
+  });
+  registerTelemetryStub({
+    async createForSession() {
+      throw new Error("insert failed");
+    },
+  });
+
+  const request = new Request("http://localhost/api/sessions/session-1/events", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ recordedAt: "2024-01-01T00:00:00.000Z" }),
+  });
+
+  const response = await POST(request, { params: { sessionId: "session-1" } });
+
+  assert.equal(response.status, 500);
+  assert.deepEqual(await response.json(), { error: "Unable to record telemetry" });
+});

--- a/web/test/api-sessions-route.test.ts
+++ b/web/test/api-sessions-route.test.ts
@@ -1,0 +1,160 @@
+import "./setupAlias";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { CreateSessionInput, Session } from "@/core/domain/session";
+import type { SessionRepository } from "@/core/app/sessions/ports";
+import { registerSessionRepository } from "@/core/app/sessions/serviceLocator";
+import { GET, POST } from "@/app/api/sessions/route";
+
+const baseSession: Session = {
+  id: "session-1",
+  name: "Evening practice",
+  description: null,
+  kind: "RACE",
+  status: "SCHEDULED",
+  scheduledStart: null,
+  scheduledEnd: null,
+  actualStart: null,
+  actualEnd: null,
+  timingProvider: "MANUAL",
+  liveRc: null,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return { ...baseSession, ...overrides };
+}
+
+function registerSessionsStub(overrides: Partial<SessionRepository> = {}) {
+  const repository: SessionRepository = {
+    async list() {
+      return [];
+    },
+    async create(input: CreateSessionInput) {
+      return makeSession({
+        id: "session-created",
+        name: input.name,
+        kind: input.kind,
+        scheduledStart: input.scheduledStart ?? null,
+        scheduledEnd: input.scheduledEnd ?? null,
+        timingProvider: input.timingProvider ?? "MANUAL",
+        liveRc: null,
+      });
+    },
+    async getById() {
+      return null;
+    },
+    ...overrides,
+  };
+
+  registerSessionRepository(repository);
+  return repository;
+}
+
+test("GET /api/sessions returns persisted sessions", async () => {
+  const expected = makeSession({ id: "session-a", name: "Sprint" });
+
+  registerSessionsStub({
+    async list() {
+      return [expected];
+    },
+  });
+
+  const response = await GET();
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { sessions: [expected] });
+});
+
+test("GET /api/sessions translates repository failures into 500", async () => {
+  registerSessionsStub({
+    async list() {
+      throw new Error("database unavailable");
+    },
+  });
+
+  const response = await GET();
+  assert.equal(response.status, 500);
+  assert.deepEqual(await response.json(), { error: "Unable to load sessions" });
+});
+
+test("POST /api/sessions creates a session when payload is valid", async () => {
+  const created = makeSession({
+    id: "session-123",
+    name: "Final",
+    kind: "RACE",
+  });
+
+  registerSessionsStub({
+    async create(input) {
+      return makeSession({
+        ...created,
+        name: input.name,
+        kind: input.kind,
+        scheduledStart: input.scheduledStart ?? null,
+        scheduledEnd: input.scheduledEnd ?? null,
+        timingProvider: input.timingProvider ?? "MANUAL",
+      });
+    },
+  });
+
+  const request = new Request("http://localhost/api/sessions", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: "Final", kind: "RACE" }),
+  });
+
+  const response = await POST(request);
+  assert.equal(response.status, 201);
+  assert.deepEqual(await response.json(), { session: created });
+});
+
+test("POST /api/sessions rejects malformed JSON payloads", async () => {
+  registerSessionsStub();
+
+  const request = new Request("http://localhost/api/sessions", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "{invalid",
+  });
+
+  const response = await POST(request);
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), { error: "Invalid JSON body" });
+});
+
+test("POST /api/sessions surfaces validation issues", async () => {
+  registerSessionsStub();
+
+  const request = new Request("http://localhost/api/sessions", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({}),
+  });
+
+  const response = await POST(request);
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    error: "Validation failed",
+    issues: ["name is required", "kind must be a recognised session kind"],
+  });
+});
+
+test("POST /api/sessions returns 500 when creation fails", async () => {
+  registerSessionsStub({
+    async create() {
+      throw new Error("write failed");
+    },
+  });
+
+  const request = new Request("http://localhost/api/sessions", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: "Practice", kind: "FP1" }),
+  });
+
+  const response = await POST(request);
+  assert.equal(response.status, 500);
+  assert.deepEqual(await response.json(), { error: "Unable to create session" });
+});

--- a/web/test/setupAlias.ts
+++ b/web/test/setupAlias.ts
@@ -26,5 +26,9 @@ const compiledRoot = path.resolve(__dirname, "..");
     const target = path.join(compiledRoot, "src", "stubs", "prisma-client");
     return originalResolve.call(this, target, parent, isMain, options);
   }
+  if (request === "next/server") {
+    const target = path.join(compiledRoot, "test", "stubs", "next-server");
+    return originalResolve.call(this, target, parent, isMain, options);
+  }
   return originalResolve.call(this, request, parent, isMain, options);
 };

--- a/web/test/stubs/next-server.ts
+++ b/web/test/stubs/next-server.ts
@@ -1,0 +1,16 @@
+export class NextResponse extends Response {
+  constructor(body?: BodyInit | null, init?: ResponseInit) {
+    super(body, init);
+  }
+
+  static json(data: unknown, init?: ResponseInit): NextResponse {
+    const headers = new Headers(init?.headers);
+    if (!headers.has("content-type")) {
+      headers.set("content-type", "application/json");
+    }
+    return new NextResponse(JSON.stringify(data), {
+      ...init,
+      headers,
+    });
+  }
+}

--- a/web/tsconfig.test.json
+++ b/web/tsconfig.test.json
@@ -13,7 +13,8 @@
     "types": ["custom-node"],
     "paths": {
       "@/*": ["./src/*"],
-      "@prisma/client": ["./src/stubs/prisma-client"]
+      "@prisma/client": ["./src/stubs/prisma-client"],
+      "next/server": ["./test/stubs/next-server"]
     }
   },
   "include": ["src/core/**/*.ts", "src/core/**/*.tsx", "src/stubs/**/*.ts", "test/**/*.ts"],


### PR DESCRIPTION
## Summary
- add node:test coverage for the /api/sessions and /api/sessions/[id]/events route handlers, exercising happy paths, validation failures, and missing-resource branches
- stub the session and telemetry service locators inside the new suites so tests remain within the documented layering boundaries (docs/design-principles.md)
- expose a Next.js response stub and alias wiring so the build:test step can emit the compiled route tests

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ce360c45988321a10b01d01bc0cb7b