### PR TITLE
docs: add doc blocks to dashboard app components

### DIFF
--- a/web/src/app/_components/DemoTelemetryPanel.tsx
+++ b/web/src/app/_components/DemoTelemetryPanel.tsx
@@ -1,3 +1,12 @@
+/**
+ * File: web/src/app/_components/DemoTelemetryPanel.tsx
+ * Purpose: Provides a client-side control for posting synthetic telemetry
+ *          samples to the API when validating ingest flows.
+ * Notable behaviours: Posts demo events to `/api/sessions/{id}/events`, shows
+ *                    toast feedback, and refreshes the router after successful
+ *                    injection.
+ */
+
 "use client";
 
 import { useState, useTransition } from "react";

--- a/web/src/app/_components/SessionForm.tsx
+++ b/web/src/app/_components/SessionForm.tsx
@@ -1,3 +1,13 @@
+/**
+ * File: web/src/app/_components/SessionForm.tsx
+ * Purpose: Client-side form for scheduling telemetry sessions from the command
+ *          centre interface.
+ * Notable behaviours: Invokes `createSessionAction` via `useFormState`,
+ *                    surfaces success and error notifications through the
+ *                    toast provider, and resets the form/timing provider after
+ *                    successful submission.
+ */
+
 "use client";
 
 import { useEffect, useRef, useState } from "react";

--- a/web/src/app/_components/SignOutButton.tsx
+++ b/web/src/app/_components/SignOutButton.tsx
@@ -1,3 +1,12 @@
+/**
+ * File: web/src/app/_components/SignOutButton.tsx
+ * Purpose: Provides a small client-side control for terminating the current
+ *          session from the dashboard header.
+ * Notable behaviours: Calls the `signOutAction` inside `useTransition` to show
+ *                    pending feedback and disables the button while the action
+ *                    resolves.
+ */
+
 "use client";
 
 import { useTransition } from "react";

--- a/web/src/app/_components/TelemetrySummaryPanel.tsx
+++ b/web/src/app/_components/TelemetrySummaryPanel.tsx
@@ -1,3 +1,13 @@
+/**
+ * File: web/src/app/_components/TelemetrySummaryPanel.tsx
+ * Purpose: Presents aggregate telemetry metrics alongside the timeline so the
+ *          crew can confirm ingest quality at a glance.
+ * Notable behaviours: Displays summary counts/averages from
+ *                    `summariseTelemetry`, swaps to an empty state when no
+ *                    samples exist, and reuses semantic accent styling per
+ *                    metric.
+ */
+
 import type { TelemetrySummary } from "@/core/app/telemetry/summariseTelemetry";
 
 export function TelemetrySummaryPanel({ summary }: { summary: TelemetrySummary }) {

--- a/web/src/app/_components/TelemetryTimeline.tsx
+++ b/web/src/app/_components/TelemetryTimeline.tsx
@@ -1,3 +1,12 @@
+/**
+ * File: web/src/app/_components/TelemetryTimeline.tsx
+ * Purpose: Renders an inline SVG chart for a session's telemetry samples inside
+ *          the command centre dashboard.
+ * Notable behaviours: Derives chart geometry with `useMemo`, builds multi-signal
+ *                    paths for speed/throttle/brake, and displays an empty state
+ *                    when no samples are available.
+ */
+
 "use client";
 
 import { useMemo } from "react";

--- a/web/src/app/_components/ToastProvider.tsx
+++ b/web/src/app/_components/ToastProvider.tsx
@@ -1,3 +1,12 @@
+/**
+ * File: web/src/app/_components/ToastProvider.tsx
+ * Purpose: Supplies a lightweight toast context for client components to raise
+ *          success/error/info notifications.
+ * Notable behaviours: Generates unique toast IDs, auto-dismisses messages after
+ *                    five seconds, and exposes a `useToast` hook that enforces
+ *                    provider usage.
+ */
+
 "use client";
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";

--- a/web/src/app/login/LoginForm.tsx
+++ b/web/src/app/login/LoginForm.tsx
@@ -1,3 +1,13 @@
+/**
+ * File: web/src/app/login/LoginForm.tsx
+ * Purpose: Handles the shared-passphrase login flow for the development
+ *          environment.
+ * Notable behaviours: Submits credentials through `signInAction` with
+ *                    `useFormState`, forwards redirect targets, and renders
+ *                    inline error messaging alongside a pending-aware submit
+ *                    button.
+ */
+
 "use client";
 
 import { useFormState, useFormStatus } from "react-dom";

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,3 +1,12 @@
+/**
+ * File: web/src/app/page.tsx
+ * Purpose: Server component composing the telemetry command centre home view.
+ * Notable behaviours: Bootstraps dependencies via `@/server/bootstrap`, loads
+ *                    sessions and telemetry data, computes summary metrics, and
+ *                    coordinates error handling/child components for the
+ *                    dashboard layout.
+ */
+
 import Link from "next/link";
 
 import "@/server/bootstrap";


### PR DESCRIPTION
## Summary
- add doc-block headers to dashboard session, telemetry, and auth components for fast orientation
- call out key behaviours such as session creation, demo telemetry injection, toast management, and aggregate rendering

## Design compliance
- Aligns with documentation-only guidance; no behavioural changes. References architectural context from [docs/design-principles.md#0-system-shape](docs/design-principles.md#0-system-shape) and UX overview in [docs/ux-principles.md#1-glanceable-under-pressure](docs/ux-principles.md#1-glanceable-under-pressure).

## Testing
- `npm run lint` *(fails: existing `@typescript-eslint/no-explicit-any` violations in web/src/stubs/prisma-client.d.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ce4e907a988321a1bb8c6851b08e67