### PR TITLE
feat(web): ensure toast timers persist across updates

### DIFF
--- a/web/src/app/_components/ToastProvider.tsx
+++ b/web/src/app/_components/ToastProvider.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
 interface Toast {
   id: number;
@@ -15,7 +24,7 @@ export interface ToastContextValue {
 
 const ToastContext = createContext<ToastContextValue | null>(null);
 
-export function ToastProvider({ children }: { children: React.ReactNode }) {
+export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([]);
 
   const notify = useCallback((toast: Omit<Toast, "id">) => {
@@ -25,19 +34,23 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
     });
   }, []);
 
+  const timerRegistryRef = useRef<ToastTimerRegistry | null>(null);
+  if (!timerRegistryRef.current) {
+    timerRegistryRef.current = createToastTimerRegistry((id) => {
+      setToasts((current) => current.filter((item) => item.id !== id));
+    });
+  }
+
   useEffect(() => {
-    if (toasts.length === 0) return;
-    const timers = toasts.map((toast) =>
-      setTimeout(() => {
-        setToasts((current) => current.filter((item) => item.id !== toast.id));
-      }, 5000),
-    );
-    return () => {
-      for (const timer of timers) {
-        clearTimeout(timer);
-      }
-    };
+    timerRegistryRef.current?.sync(toasts);
   }, [toasts]);
+
+  useEffect(() => {
+    const registry = timerRegistryRef.current;
+    return () => {
+      registry?.dispose();
+    };
+  }, []);
 
   const value = useMemo(() => ({ notify }), [notify]);
 
@@ -67,6 +80,48 @@ export function useToast() {
     throw new Error("useToast must be used within a ToastProvider");
   }
   return context;
+}
+
+export interface ToastTimerRegistry {
+  sync(toasts: Toast[]): void;
+  dispose(): void;
+}
+
+export function createToastTimerRegistry(
+  onExpire: (id: number) => void,
+  dismissAfterMs = 5000,
+): ToastTimerRegistry {
+  const timers = new Map<number, ReturnType<typeof setTimeout>>();
+
+  return {
+    sync(toasts) {
+      const activeIds = new Set(toasts.map((toast) => toast.id));
+
+      for (const [id, handle] of timers) {
+        if (!activeIds.has(id)) {
+          clearTimeout(handle);
+          timers.delete(id);
+        }
+      }
+
+      for (const toast of toasts) {
+        if (timers.has(toast.id)) continue;
+
+        const handle = setTimeout(() => {
+          timers.delete(toast.id);
+          onExpire(toast.id);
+        }, dismissAfterMs);
+
+        timers.set(toast.id, handle);
+      }
+    },
+    dispose() {
+      for (const handle of timers.values()) {
+        clearTimeout(handle);
+      }
+      timers.clear();
+    },
+  };
 }
 
 function variantClass(variant: Toast["variant"]) {

--- a/web/src/stubs/prisma-client.js
+++ b/web/src/stubs/prisma-client.js
@@ -1,0 +1,196 @@
+const { randomUUID } = require("node:crypto");
+
+function now() {
+  return new Date();
+}
+
+function toDate(value) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function mergeRecord(base, updates) {
+  return Object.assign({}, base, updates);
+}
+
+function createUpsert(store, keyResolver) {
+  return async (args) => {
+    const key = keyResolver(args.where);
+    const existing = store.get(key);
+    const record = existing ? mergeRecord(existing, args.update) : args.create;
+    store.set(key, record);
+    return record;
+  };
+}
+
+class PrismaClient {
+  constructor() {
+    this._sessions = new Map();
+    this._telemetrySamples = new Map();
+    this._liveRcSourceCache = new Map();
+    this._liveRcEvents = new Map();
+    this._liveRcClasses = new Map();
+    this._liveRcRounds = new Map();
+    this._liveRcHeats = new Map();
+    this._liveRcEntries = new Map();
+    this._liveRcResults = new Map();
+    this._liveRcLaps = new Map();
+    this._liveRcRoundRankings = new Map();
+    this._liveRcMultiMainStandings = new Map();
+    this._liveRcEventOverallResults = new Map();
+
+    this.session = {
+      create: async (args) => {
+        const id = args.data.id ?? `session-${randomUUID()}`;
+        const created = {
+          id,
+          name: args.data.name,
+          description: args.data.description ?? null,
+          kind: args.data.kind,
+          status: args.data.status ?? "SCHEDULED",
+          scheduledStart: toDate(args.data.scheduledStart),
+          scheduledEnd: toDate(args.data.scheduledEnd),
+          actualStart: toDate(args.data.actualStart),
+          actualEnd: toDate(args.data.actualEnd),
+          timingProvider: args.data.timingProvider,
+          liveRcHeatId: args.data.liveRcHeatId ?? null,
+          createdAt: now(),
+          updatedAt: now(),
+          liveRcHeat: null,
+        };
+        this._sessions.set(id, created);
+        return created;
+      },
+      findMany: async (args) => {
+        const sessions = Array.from(this._sessions.values());
+        sessions.sort((a, b) =>
+          args.orderBy.createdAt === "asc"
+            ? a.createdAt.getTime() - b.createdAt.getTime()
+            : b.createdAt.getTime() - a.createdAt.getTime(),
+        );
+        return typeof args.take === "number" ? sessions.slice(0, args.take) : sessions;
+      },
+      findUnique: async (args) => {
+        return this._sessions.get(args.where.id) ?? null;
+      },
+    };
+
+    this.telemetrySample = {
+      create: async (args) => {
+        const id = args.data.id ?? `telemetry-${randomUUID()}`;
+        const sample = {
+          id,
+          sessionId: args.data.sessionId,
+          recordedAt: toDate(args.data.recordedAt) ?? now(),
+          speedKph: args.data.speedKph ?? null,
+          throttlePct: args.data.throttlePct ?? null,
+          brakePct: args.data.brakePct ?? null,
+          rpm: args.data.rpm ?? null,
+          gear: args.data.gear ?? null,
+          createdAt: now(),
+        };
+        const existing = this._telemetrySamples.get(sample.sessionId) ?? [];
+        existing.push(sample);
+        this._telemetrySamples.set(sample.sessionId, existing);
+        return sample;
+      },
+      findMany: async (args) => {
+        const samples = (this._telemetrySamples.get(args.where.sessionId) ?? []).slice();
+        samples.sort((a, b) =>
+          args.orderBy.recordedAt === "asc"
+            ? a.recordedAt.getTime() - b.recordedAt.getTime()
+            : b.recordedAt.getTime() - a.recordedAt.getTime(),
+        );
+        return typeof args.take === "number" ? samples.slice(0, args.take) : samples;
+      },
+    };
+
+    this.liveRcSourceCache = {
+      findUnique: async (args) => {
+        return this._liveRcSourceCache.get(args.where.url) ?? null;
+      },
+      upsert: async (args) => {
+        const existing = this._liveRcSourceCache.get(args.where.url);
+        const record = existing ? mergeRecord(existing, args.update) : args.create;
+        this._liveRcSourceCache.set(args.where.url, record);
+        return record;
+      },
+    };
+
+    this.liveRcEvent = {
+      upsert: createUpsert(this._liveRcEvents, (where) => String(where.externalEventId)),
+    };
+
+    this.liveRcClass = {
+      upsert: createUpsert(
+        this._liveRcClasses,
+        (where) => `${where.eventId_externalClassId.eventId}:${where.eventId_externalClassId.externalClassId}`,
+      ),
+    };
+
+    this.liveRcRound = {
+      upsert: createUpsert(
+        this._liveRcRounds,
+        (where) => `${where.classId_type_ordinal.classId}:${where.classId_type_ordinal.type}:${where.classId_type_ordinal.ordinal}`,
+      ),
+    };
+
+    this.liveRcHeat = {
+      upsert: createUpsert(
+        this._liveRcHeats,
+        (where) => `${where.classId_externalHeatId.classId}:${where.classId_externalHeatId.externalHeatId}`,
+      ),
+    };
+
+    this.liveRcEntry = {
+      upsert: createUpsert(
+        this._liveRcEntries,
+        (where) => `${where.classId_externalEntryId.classId}:${where.classId_externalEntryId.externalEntryId}`,
+      ),
+    };
+
+    this.liveRcResult = {
+      upsert: createUpsert(
+        this._liveRcResults,
+        (where) => `${where.heatId_entryId.heatId}:${where.heatId_entryId.entryId}`,
+      ),
+    };
+
+    this.liveRcLap = {
+      upsert: createUpsert(
+        this._liveRcLaps,
+        (where) => `${where.heatId_entryId_lapNo.heatId}:${where.heatId_entryId_lapNo.entryId}:${where.heatId_entryId_lapNo.lapNo}`,
+      ),
+    };
+
+    this.liveRcRoundRanking = {
+      upsert: createUpsert(
+        this._liveRcRoundRankings,
+        (where) =>
+          `${where.roundId_entryId_rankMode.roundId}:${where.roundId_entryId_rankMode.entryId}:${where.roundId_entryId_rankMode.rankMode}`,
+      ),
+    };
+
+    this.liveRcMultiMainStanding = {
+      upsert: createUpsert(
+        this._liveRcMultiMainStandings,
+        (where) => `${where.classId_entryId.classId}:${where.classId_entryId.entryId}`,
+      ),
+    };
+
+    this.liveRcEventOverallResult = {
+      upsert: createUpsert(
+        this._liveRcEventOverallResults,
+        (where) => `${where.classId_entryId.classId}:${where.classId_entryId.entryId}`,
+      ),
+    };
+
+    this.$queryRaw = async () => [];
+  }
+}
+
+module.exports = {
+  PrismaClient,
+  Prisma: {},
+};

--- a/web/test/toast-provider.test.tsx
+++ b/web/test/toast-provider.test.tsx
@@ -1,0 +1,43 @@
+import "./setupAlias";
+import assert from "node:assert/strict";
+import test, { mock } from "node:test";
+
+import {
+  createToastTimerRegistry,
+  type ToastTimerRegistry,
+} from "@/app/_components/ToastProvider";
+
+test("an early toast is dismissed after five seconds even when later toasts appear", () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+
+  const removals: number[] = [];
+  const registry: ToastTimerRegistry = createToastTimerRegistry((id) => {
+    removals.push(id);
+  });
+
+  try {
+    registry.sync([
+      { id: 1, title: "Early toast" },
+    ]);
+
+    mock.timers.tick(3000);
+    assert.deepEqual(removals, []);
+
+    registry.sync([
+      { id: 1, title: "Early toast" },
+      { id: 2, title: "Later toast" },
+    ]);
+
+    mock.timers.tick(1999);
+    assert.deepEqual(removals, []);
+
+    mock.timers.tick(1);
+    assert.deepEqual(removals, [1]);
+
+    mock.timers.tick(5000);
+    assert.deepEqual(removals, [1, 2]);
+  } finally {
+    registry.dispose();
+    mock.timers.reset();
+  }
+});

--- a/web/tsconfig.test.json
+++ b/web/tsconfig.test.json
@@ -11,6 +11,7 @@
     "baseUrl": ".",
     "typeRoots": ["./types"],
     "types": ["custom-node"],
+    "jsx": "react-jsx",
     "paths": {
       "@/*": ["./src/*"],
       "@prisma/client": ["./src/stubs/prisma-client"],
@@ -18,10 +19,12 @@
     }
   },
   "include": [
+    "src/app/_components/ToastProvider.tsx",
     "src/core/**/*.ts",
     "src/core/**/*.tsx",
     "src/stubs/**/*.d.ts",
-    "test/**/*.ts"
+    "test/**/*.ts",
+    "test/**/*.tsx"
   ],
   "exclude": ["node_modules"]
 }

--- a/web/types/custom-node/index.d.ts
+++ b/web/types/custom-node/index.d.ts
@@ -4,7 +4,23 @@ export = assertStrict;
 }
 
 declare module "node:test" {
-  export type TestFn = (t: unknown) => Promise<void> | void;
+  export interface MockTimers {
+    enable(options?: { apis?: string[] }): void;
+    tick(milliseconds: number): void;
+    reset(): void;
+  }
+
+  export interface MockTracker {
+    timers: MockTimers;
+  }
+
+  export const mock: MockTracker;
+
+  export interface TestContext {
+    mock: MockTracker;
+  }
+
+  export type TestFn = (t: TestContext) => Promise<void> | void;
   export default function test(name: string, fn: TestFn): Promise<void>;
   export function test(name: string, fn: TestFn): Promise<void>;
 }


### PR DESCRIPTION
## Summary
- ensure each toast schedules its dismissal once via a reusable registry
- add a lightweight Prisma client runtime stub so tests can resolve the alias
- cover the regression with a focused timer test for the toast queue

## Design / UX
- Supports UX Principle 4 (Perceived performance) by keeping transient toasts responsive while new ones are queued.
- Follows Design Principle 10 (Testing) by extending automated coverage around the toast lifecycle.

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ce4e8f3be48321bf533bff7cf45b08