### PR TITLE
Use React useActionState in session form

### DIFF
--- a/web/src/app/_components/SessionForm.tsx
+++ b/web/src/app/_components/SessionForm.tsx
@@ -10,8 +10,8 @@
 
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { useFormState, useFormStatus } from "react-dom";
+import { useActionState, useEffect, useRef, useState } from "react";
+import { useFormStatus } from "react-dom";
 import { SESSION_KINDS, TIMING_PROVIDERS } from "@/core/domain/session";
 import type { ActionResult } from "../actions";
 import { createSessionAction } from "../actions";
@@ -20,7 +20,7 @@ import { useToast } from "./ToastProvider";
 const INITIAL_STATE: ActionResult = { success: false };
 
 export function SessionForm() {
-  const [state, formAction] = useFormState(createSessionAction, INITIAL_STATE);
+  const [state, formAction] = useActionState(createSessionAction, INITIAL_STATE);
   const { notify } = useToast();
   const [timingProvider, setTimingProvider] = useState("MANUAL");
   const formRef = useRef<HTMLFormElement>(null);


### PR DESCRIPTION
## Summary
- switch the session form client component to import `useActionState` from React and keep `useFormStatus` from `react-dom`
- update the session form to call `useActionState(createSessionAction, INITIAL_STATE)` so the home page no longer triggers the rename error while keeping server actions wired up

## Testing
- npm run lint *(fails: existing lint rule violations in web/src/stubs/prisma-client.{d.ts,js})*

## Design compliance
- Respects design principle 0 (system shape & layering) by keeping the client component self-contained within the `web` layer.
- Upholds UX principle 5 (errors guide recovery) by preserving existing error handling behaviour.

## Risk & Rollback
- Low risk: revert this commit to restore the previous hook usage if any issues surface.


------
https://chatgpt.com/codex/tasks/task_e_68ce576f9a408321b77a68c75175ae02