### PR TITLE
Fix login form action state and lazy-load Prisma client

### DIFF
--- a/web/src/app/login/LoginForm.tsx
+++ b/web/src/app/login/LoginForm.tsx
@@ -3,7 +3,7 @@
  * Purpose: Handles the shared-passphrase login flow for the development
  *          environment.
  * Notable behaviours: Submits credentials through `signInAction` with
- *                    `useFormState`, forwards redirect targets, and renders
+ *                    `useActionState`, forwards redirect targets, and renders
  *                    inline error messaging alongside a pending-aware submit
  *                    button.
  */
@@ -19,7 +19,7 @@ import { signInAction } from "./actions";
 const INITIAL_STATE: AuthResult = { success: false };
 
 export function LoginForm({ redirectTo }: { redirectTo: string }) {
-  const [state, action] = useActionState(signInAction, INITIAL_STATE);
+  const [state, action] = useActionState<AuthResult, FormData>(signInAction, INITIAL_STATE);
 
   return (
     <form action={action} className="space-y-5 rounded-lg border border-neutral-200 bg-white p-6 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">

--- a/web/src/core/infra/db/prismaClient.ts
+++ b/web/src/core/infra/db/prismaClient.ts
@@ -19,18 +19,29 @@ const globalForPrisma = globalThis as unknown as {
   prisma?: PrismaClient;
 };
 
-// Instantiate a single Prisma client. In development we elevate logging to
-// include queries, warnings, and errors so that developers can observe the SQL
-// being executed without additional tooling.
-export const prisma: PrismaClient =
-  globalForPrisma.prisma ??
-  new PrismaClient({
+function createPrismaClient(): PrismaClient {
+  return new PrismaClient({
     log: process.env.NODE_ENV === "development" ? ["query", "warn", "error"] : ["error"],
   } satisfies Prisma.PrismaClientOptions);
+}
 
-if (process.env.NODE_ENV !== "production") {
-  // Persist the client on the global object so subsequent imports reuse the
-  // same instance. Production environments should prefer short-lived clients
-  // per request, so we skip caching there.
-  globalForPrisma.prisma = prisma;
+// Lazily resolve the Prisma client so that modules importing this helper do not
+// trigger database initialisation during static evaluation. This keeps build
+// time environments (and unit tests that rely on the Prisma stub) free from
+// connection attempts while still providing a cached client in development.
+export function getPrismaClient(): PrismaClient {
+  if (globalForPrisma.prisma) {
+    return globalForPrisma.prisma;
+  }
+
+  const client = createPrismaClient();
+
+  if (process.env.NODE_ENV !== "production") {
+    // Persist the client on the global object so subsequent imports reuse the
+    // same instance. Production environments should prefer short-lived clients
+    // per request, so we skip caching there.
+    globalForPrisma.prisma = client;
+  }
+
+  return client;
 }

--- a/web/src/core/infra/sessions/prismaSessionRepository.ts
+++ b/web/src/core/infra/sessions/prismaSessionRepository.ts
@@ -6,13 +6,14 @@
  */
 
 import type { Prisma } from "@prisma/client";
-import { prisma } from "@/core/infra/db/prismaClient";
+import { getPrismaClient } from "@/core/infra/db/prismaClient";
 import type { CreateSessionInput, Session, SessionLiveRcMetadata, TimingProvider } from "@/core/domain/session";
 import type { SessionRepository } from "@/core/app/sessions/ports";
 import { registerSessionRepository } from "@/core/app/sessions/serviceLocator";
 
 const repository: SessionRepository = {
   async create(data: CreateSessionInput) {
+    const prisma = getPrismaClient();
     // Persist the session while letting Prisma coerce optional date fields into
     // nullable columns. We include LiveRC relations so the caller receives a
     // complete view immediately after creation.
@@ -32,6 +33,7 @@ const repository: SessionRepository = {
     return mapSession(created);
   },
   async list() {
+    const prisma = getPrismaClient();
     // Limit the result set to the latest 25 sessions to keep payload sizes
     // predictable for the API.
     const sessions = await prisma.session.findMany({
@@ -42,6 +44,7 @@ const repository: SessionRepository = {
     return sessions.map(mapSession);
   },
   async getById(id) {
+    const prisma = getPrismaClient();
     const session = await prisma.session.findUnique({
       where: { id },
       include: LIVE_RC_INCLUDE,

--- a/web/src/core/infra/system/hasPendingMigrations.test.ts
+++ b/web/src/core/infra/system/hasPendingMigrations.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { promises as fs } from "node:fs";
 
-import { prisma } from "@/core/infra/db/prismaClient";
+import { getPrismaClient } from "@/core/infra/db/prismaClient";
 
 import { hasPendingMigrations } from "./hasPendingMigrations";
 
@@ -21,6 +21,7 @@ function patchFs(entries: DirentLike[]) {
 }
 
 function patchQueryRaw<T>(implementation: () => Promise<T>) {
+  const prisma = getPrismaClient();
   const original = prisma.$queryRaw;
   prisma.$queryRaw = (implementation as unknown) as typeof prisma.$queryRaw;
   return () => {

--- a/web/src/core/infra/system/hasPendingMigrations.ts
+++ b/web/src/core/infra/system/hasPendingMigrations.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 
-import { prisma } from "@/core/infra/db/prismaClient";
+import { getPrismaClient } from "@/core/infra/db/prismaClient";
 
 const MIGRATIONS_DIRECTORY = path.resolve(process.cwd(), "..", "prisma", "migrations");
 
@@ -36,6 +36,7 @@ async function readMigrationDirectories(): Promise<string[] | null> {
 }
 
 async function readAppliedMigrations(): Promise<AppliedMigrationRow[]> {
+  const prisma = getPrismaClient();
   try {
     return await prisma.$queryRaw<AppliedMigrationRow[]>`
       SELECT "migration_name"

--- a/web/src/core/infra/system/prismaHealthIndicator.ts
+++ b/web/src/core/infra/system/prismaHealthIndicator.ts
@@ -5,7 +5,7 @@
  */
 
 import { performance } from "node:perf_hooks";
-import { prisma } from "@/core/infra/db/prismaClient";
+import { getPrismaClient } from "@/core/infra/db/prismaClient";
 import type { ReadinessProbeResult } from "@/core/app/system/ports";
 import { registerReadinessDependencies } from "@/core/app/system/serviceLocator";
 
@@ -14,6 +14,7 @@ export async function databaseProbe(): Promise<ReadinessProbeResult> {
   try {
     // A lightweight `SELECT 1` ensures connectivity without impacting
     // production traffic or requiring table-level access.
+    const prisma = getPrismaClient();
     await prisma.$queryRaw`SELECT 1`;
     return {
       name: "database",

--- a/web/src/core/infra/telemetry/prismaTelemetryRepository.ts
+++ b/web/src/core/infra/telemetry/prismaTelemetryRepository.ts
@@ -6,12 +6,13 @@
 import type { Prisma } from "@prisma/client";
 
 import type { TelemetrySample } from "@/core/domain/telemetry";
-import { prisma } from "@/core/infra/db/prismaClient";
+import { getPrismaClient } from "@/core/infra/db/prismaClient";
 import type { TelemetryRepository } from "@/core/app/telemetry/ports";
 import { registerTelemetryRepository } from "@/core/app/telemetry/serviceLocator";
 
 const repository: TelemetryRepository = {
   async createForSession(sessionId, data) {
+    const prisma = getPrismaClient();
     const created = await prisma.telemetrySample.create({
       data: {
         sessionId,
@@ -28,6 +29,7 @@ const repository: TelemetryRepository = {
   },
 
   async listForSession(sessionId, options) {
+    const prisma = getPrismaClient();
     const order = options?.order ?? "asc";
     const limit = options?.limit ?? 500;
     const samples = await prisma.telemetrySample.findMany({


### PR DESCRIPTION
## Summary
- update the login form to call `useActionState` with explicit generics and document the hook change
- lazily resolve the Prisma client so importing infra modules during static evaluation no longer instantiates the database connection
- fetch the Prisma client on demand in repositories, health checks, and migration helpers so they align with the lazy factory

## Design compliance
- Follows layering rules in [docs/design-principles.md §0 System shape](docs/design-principles.md#0-system-shape) by keeping Prisma access inside infra helpers and exposing only lazy accessors.
- Keeps UX copy untouched, preserving guidance in [docs/ux-principles.md §5 Errors guide recovery](docs/ux-principles.md#5-errors-guide-recovery).

## Testing
- Attempted `npm run build:test` (TypeScript compilation ran for ~70s and was interrupted to avoid stalling the session).


------
https://chatgpt.com/codex/tasks/task_e_68ce5d1259648321b33d050037c7d234