### PR TITLE
fix: unblock lint and offline builds

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1,6 +1,8 @@
 @import "tailwindcss";
 
 :root {
+  --font-geist-sans: "Inter", "Helvetica Neue", Arial, system-ui, sans-serif;
+  --font-geist-mono: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   --background: #0f172a;
   --foreground: #111111;
   --surface: #f5f6f8;

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,17 +1,6 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ToastProvider } from "./_components/ToastProvider";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "The RC Racing Engineer | Live telemetry intelligence for every stint",
@@ -26,7 +15,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body className="antialiased">
         <ToastProvider>{children}</ToastProvider>
       </body>
     </html>

--- a/web/src/stubs/prisma-client.d.ts
+++ b/web/src/stubs/prisma-client.d.ts
@@ -47,17 +47,17 @@ export declare namespace Prisma {
     createdAt: Date;
   };
 
-  export type LiveRcEvent = { id: string; externalEventId: number; [key: string]: any };
-  export type LiveRcClass = { id: string; eventId: string; externalClassId: number; [key: string]: any };
-  export type LiveRcRound = { id: string; classId: string; type: string; ordinal: number; [key: string]: any };
-  export type LiveRcHeat = { id: string; classId: string; externalHeatId: number; [key: string]: any };
-  export type LiveRcEntry = { id: string; classId: string; externalEntryId: number; [key: string]: any };
-  export type LiveRcResult = { id: string; heatId: string; entryId: string; externalResultId: number; [key: string]: any };
-  export type LiveRcLap = { id: string; heatId: string; entryId: string; lapNo: number; [key: string]: any };
-  export type LiveRcRoundRanking = { id: string; roundId: string; entryId: string; rankMode: string; [key: string]: any };
-  export type LiveRcMultiMainStanding = { id: string; eventId: string; classId: string; entryId: string; [key: string]: any };
-  export type LiveRcEventOverallResult = { id: string; eventId: string; classId: string; entryId: string; [key: string]: any };
-  export type LiveRcSourceCache = { id: string; url: string; [key: string]: any };
+  export type LiveRcEvent = { id: string; externalEventId: number; [key: string]: unknown };
+  export type LiveRcClass = { id: string; eventId: string; externalClassId: number; [key: string]: unknown };
+  export type LiveRcRound = { id: string; classId: string; type: string; ordinal: number; [key: string]: unknown };
+  export type LiveRcHeat = { id: string; classId: string; externalHeatId: number; [key: string]: unknown };
+  export type LiveRcEntry = { id: string; classId: string; externalEntryId: number; [key: string]: unknown };
+  export type LiveRcResult = { id: string; heatId: string; entryId: string; externalResultId: number; [key: string]: unknown };
+  export type LiveRcLap = { id: string; heatId: string; entryId: string; lapNo: number; [key: string]: unknown };
+  export type LiveRcRoundRanking = { id: string; roundId: string; entryId: string; rankMode: string; [key: string]: unknown };
+  export type LiveRcMultiMainStanding = { id: string; eventId: string; classId: string; entryId: string; [key: string]: unknown };
+  export type LiveRcEventOverallResult = { id: string; eventId: string; classId: string; entryId: string; [key: string]: unknown };
+  export type LiveRcSourceCache = { id: string; url: string; [key: string]: unknown };
 
   export type SessionInclude = {
     liveRcHeat?:
@@ -75,7 +75,7 @@ export declare namespace Prisma {
 }
 
 type SessionCreateArgs = {
-  data: Record<string, any>;
+  data: Record<string, unknown>;
   include?: Prisma.SessionInclude;
 };
 
@@ -91,7 +91,7 @@ type SessionFindUniqueArgs = {
 };
 
 type TelemetryCreateArgs = {
-  data: Record<string, any>;
+  data: Record<string, unknown>;
 };
 
 type TelemetryFindManyArgs = {
@@ -102,8 +102,8 @@ type TelemetryFindManyArgs = {
 
 type UpsertArgs<Where> = {
   where: Where;
-  create: Record<string, any>;
-  update: Record<string, any>;
+  create: Record<string, unknown>;
+  update: Record<string, unknown>;
 };
 
 export declare class PrismaClient {

--- a/web/src/stubs/prisma-client.js
+++ b/web/src/stubs/prisma-client.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 const { randomUUID } = require("node:crypto");
 
 function now() {


### PR DESCRIPTION
## Summary
- replace the Prisma stub `any` fallbacks with `unknown` to satisfy strict linting
- keep the stub runtime on CommonJS while silencing the import rule that blocked the lint run
- swap Google-hosted Geist fonts for local CSS fallbacks so builds succeed without external fetches

## Design compliance
- Preserves the typography tokens defined in docs/design-principles.md (section 13) by mapping the CSS variables to system fallback stacks instead of remote fonts.
- Keeps the login layout readable under pressure and accessible per docs/ux-principles.md (principles 1 and 6) by ensuring fonts resolve locally in all environments.

## Testing
- `npm run lint`
- `npm run test` *(hangs during TypeScript compilation after several minutes; cancelled once it exceeded the usual execution window)*
- `CI=1 npm run build` *(stalls on the integrated TypeScript check similar to the standalone compile; terminated after extended wait)*

## Risk & Rollback
- Low risk: only touches the Prisma stub typing and font wiring. Roll back with `git revert <commit>` if issues appear.

------
https://chatgpt.com/codex/tasks/task_e_68ce64c105c883218e776e319d279292