### PR TITLE
Sanitize login redirects

### DIFF
--- a/web/src/app/login/actions.ts
+++ b/web/src/app/login/actions.ts
@@ -3,6 +3,8 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { normalizeRedirectTarget } from "./redirect";
+
 export interface AuthResult {
   success: boolean;
   error?: string;
@@ -12,7 +14,7 @@ const COOKIE_NAME = "rc-dev-auth";
 
 export async function signInAction(_prev: AuthResult, formData: FormData): Promise<AuthResult> {
   const passcode = `${formData.get("passcode") ?? ""}`.trim();
-  const redirectTo = `${formData.get("redirect") ?? "/"}`;
+  const redirectTo = normalizeRedirectTarget(formData.get("redirect"));
   const expected = process.env.DEV_AUTH_PASSWORD ?? "engineer";
 
   if (!passcode) {
@@ -31,7 +33,7 @@ export async function signInAction(_prev: AuthResult, formData: FormData): Promi
     maxAge: 60 * 60 * 12,
   });
 
-  redirect(redirectTo || "/");
+  redirect(redirectTo);
 }
 
 export async function signOutAction() {

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,13 +1,14 @@
 import type { Metadata } from "next";
 
 import { LoginForm } from "./LoginForm";
+import { normalizeRedirectTarget } from "./redirect";
 
 export const metadata: Metadata = {
   title: "Sign in | RC Racing Engineer",
 };
 
 export default function LoginPage({ searchParams }: { searchParams?: { redirect?: string } }) {
-  const redirectTo = searchParams?.redirect ?? "/";
+  const redirectTo = normalizeRedirectTarget(searchParams?.redirect);
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-surface px-6 py-12">

--- a/web/src/app/login/redirect.ts
+++ b/web/src/app/login/redirect.ts
@@ -1,0 +1,20 @@
+export function normalizeRedirectTarget(target: unknown): string {
+  if (typeof target !== "string") {
+    return "/";
+  }
+
+  const trimmed = target.trim();
+  if (!trimmed) {
+    return "/";
+  }
+
+  if (!trimmed.startsWith("/")) {
+    return "/";
+  }
+
+  if (trimmed.startsWith("//")) {
+    return "/";
+  }
+
+  return trimmed;
+}

--- a/web/test/login-redirect.test.ts
+++ b/web/test/login-redirect.test.ts
@@ -1,0 +1,71 @@
+// @ts-nocheck
+
+import "./setupAlias";
+import assert from "node:assert/strict";
+import test, { mock } from "node:test";
+
+const redirectCalls: string[] = [];
+const redirectSignal = new Error("redirect invoked");
+
+mock.module("next/navigation", () => ({
+  redirect(target: string) {
+    redirectCalls.push(target);
+    throw redirectSignal;
+  },
+}));
+
+mock.module("next/headers", () => ({
+  cookies() {
+    return {
+      set: () => {},
+      delete: () => {},
+    };
+  },
+}));
+
+async function invokeSignIn(redirectTarget: string) {
+  const { signInAction } = await import("@/app/login/actions");
+  const formData = {
+    get(name: string) {
+      if (name === "passcode") {
+        return "tower";
+      }
+      if (name === "redirect") {
+        return redirectTarget;
+      }
+      return null;
+    },
+  } as unknown as FormData;
+
+  try {
+    await signInAction({ success: false }, formData);
+    assert.fail("expected redirect to throw");
+  } catch (error) {
+    assert.equal(error, redirectSignal);
+  }
+}
+
+test("signInAction preserves in-app redirect targets", async () => {
+  redirectCalls.length = 0;
+  process.env.DEV_AUTH_PASSWORD = "tower";
+
+  await invokeSignIn("/garage");
+
+  assert.equal(redirectCalls.at(-1), "/garage");
+});
+
+test("signInAction rejects external redirect targets", async () => {
+  redirectCalls.length = 0;
+  process.env.DEV_AUTH_PASSWORD = "tower";
+
+  await invokeSignIn("https://evil.example/attack");
+
+  assert.equal(redirectCalls.at(-1), "/");
+});
+
+test("normalizeRedirectTarget guards against protocol-relative redirects", async () => {
+  const { normalizeRedirectTarget } = await import("@/app/login/redirect");
+
+  assert.equal(normalizeRedirectTarget("//evil.example"), "/");
+  assert.equal(normalizeRedirectTarget("/hangar"), "/hangar");
+});


### PR DESCRIPTION
## Summary
- harden the login server action by normalising redirect targets before issuing a redirect
- reuse the same normalisation when rendering the login page so unsafe values are never echoed
- add tests that assert external destinations are rejected while in-app paths continue to work

## Design compliance
- Security guardrails follow the requirements in docs/design-principles.md §7 (Security & secrets).
- Defaulting to a safe in-app route aligns with docs/ux-principles.md §5 (Errors guide recovery).

## Testing
- `npm test` *(fails: TypeScript compiler process never finishes in the container after multiple 5+ minute attempts; manual runs were aborted to unblock the session)*

## Risk & Rollback
- Low risk, revert this commit if login navigation regresses; fallback redirect remains `/`.


------
https://chatgpt.com/codex/tasks/task_e_68ce8dd7d8f083219670784a67f4177e