### PR TITLE
Enforce session event pagination limits

### DIFF
--- a/web/src/app/api/sessions/[sessionId]/events/route.ts
+++ b/web/src/app/api/sessions/[sessionId]/events/route.ts
@@ -11,14 +11,25 @@ import { getSession } from "@/core/app/sessions/getSession";
 import { listTelemetryForSession } from "@/core/app/telemetry/listTelemetryForSession";
 import { recordTelemetryEvent } from "@/core/app/telemetry/recordTelemetryEvent";
 
+const MAX_LIMIT = 500;
+
 export async function GET(request: Request, { params }: { params: { sessionId: string } }) {
   const { sessionId } = params;
   const url = new URL(request.url);
   const limitParam = url.searchParams.get("limit");
   const limit = limitParam ? Number.parseInt(limitParam, 10) : undefined;
 
-  if (limitParam && (Number.isNaN(limit) || limit! <= 0)) {
-    return NextResponse.json({ error: "limit must be a positive number" }, { status: 400 });
+  if (limitParam) {
+    if (Number.isNaN(limit) || limit <= 0) {
+      return NextResponse.json({ error: "limit must be a positive number" }, { status: 400 });
+    }
+
+    if (limit > MAX_LIMIT) {
+      return NextResponse.json(
+        { error: `limit must be less than or equal to ${MAX_LIMIT}` },
+        { status: 400 },
+      );
+    }
   }
 
   try {

--- a/web/src/core/infra/telemetry/prismaTelemetryRepository.ts
+++ b/web/src/core/infra/telemetry/prismaTelemetryRepository.ts
@@ -31,7 +31,7 @@ const repository: TelemetryRepository = {
   async listForSession(sessionId, options) {
     const prisma = getPrismaClient();
     const order = options?.order ?? "asc";
-    const limit = options?.limit ?? 500;
+    const limit = Math.min(options?.limit ?? 500, 500);
     const samples = await prisma.telemetrySample.findMany({
       where: { sessionId },
       orderBy: { recordedAt: order },

--- a/web/test/api-session-events-route.test.ts
+++ b/web/test/api-session-events-route.test.ts
@@ -122,6 +122,17 @@ test("GET /api/sessions/:id/events validates limit query", async () => {
   assert.deepEqual(await response.json(), { error: "limit must be a positive number" });
 });
 
+test("GET /api/sessions/:id/events rejects limit values above the cap", async () => {
+  registerSessionStub();
+  registerTelemetryStub();
+
+  const request = new Request("http://localhost/api/sessions/session-1/events?limit=999");
+  const response = await GET(request, { params: { sessionId: "session-1" } });
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), { error: "limit must be less than or equal to 500" });
+});
+
 test("GET /api/sessions/:id/events returns 404 when session missing", async () => {
   registerSessionStub({
     async getById() {


### PR DESCRIPTION
## Summary
- reject session event queries that request more than 500 records to protect the API and database
- clamp repository-level fetches to the same ceiling as a defensive guardrail
- cover the new limit validation with an API contract test

## Testing
- ⚠️ `npm test` *(tsc -p tsconfig.test.json did not finish after ~20 minutes, so the run was aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8ddaaa1083219c8a186ffb7eca95