### PR TITLE
Allow telemetry fetch when defaulting to first session

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -24,6 +24,7 @@ import { TelemetrySummaryPanel } from "./_components/TelemetrySummaryPanel";
 import { DemoTelemetryPanel } from "./_components/DemoTelemetryPanel";
 import { SignOutButton } from "./_components/SignOutButton";
 import { LiveRcHeatResultsChart } from "./_components/LiveRcHeatResultsChart";
+import { shouldLoadTelemetry } from "./telemetryLoadingGuard";
 
 const timeFormatter = new Intl.DateTimeFormat("en-GB", {
   dateStyle: "medium",
@@ -60,8 +61,12 @@ export default async function Home({ searchParams }: { searchParams?: { sessionI
 
   let samples: TelemetrySample[] = [];
   let samplesError: string | null = null;
-  const shouldLoadTelemetry = typeof normalizedSessionId === "string" && normalizedSessionId.length > 0;
-  if (shouldLoadTelemetry && selectedSessionId) {
+  const allowTelemetryFetch = shouldLoadTelemetry({
+    selectedSessionId,
+    normalizedSessionId,
+    sessionMatchingNormalized,
+  });
+  if (allowTelemetryFetch && selectedSessionId) {
     try {
       samples = await listTelemetryForSession(selectedSessionId, { order: "asc" });
     } catch (error) {

--- a/web/src/app/telemetryLoadingGuard.ts
+++ b/web/src/app/telemetryLoadingGuard.ts
@@ -1,0 +1,21 @@
+export interface TelemetryLoadingGuardInput {
+  selectedSessionId: string | null;
+  normalizedSessionId: string | null;
+  sessionMatchingNormalized: { id: string } | null;
+}
+
+export function shouldLoadTelemetry({
+  selectedSessionId,
+  normalizedSessionId,
+  sessionMatchingNormalized,
+}: TelemetryLoadingGuardInput): boolean {
+  if (selectedSessionId == null) {
+    return false;
+  }
+
+  if (normalizedSessionId === null) {
+    return true;
+  }
+
+  return sessionMatchingNormalized !== null;
+}

--- a/web/test/telemetry-loading-guard.test.ts
+++ b/web/test/telemetry-loading-guard.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldLoadTelemetry } from "@/app/telemetryLoadingGuard";
+
+test("should load telemetry when falling back to the first available session", () => {
+  const result = shouldLoadTelemetry({
+    selectedSessionId: "session-1",
+    normalizedSessionId: null,
+    sessionMatchingNormalized: null,
+  });
+
+  assert.equal(result, true);
+});
+
+test("should load telemetry when the normalized session matches an existing session", () => {
+  const result = shouldLoadTelemetry({
+    selectedSessionId: "session-1",
+    normalizedSessionId: "session-1",
+    sessionMatchingNormalized: { id: "session-1" },
+  });
+
+  assert.equal(result, true);
+});
+
+test("should block telemetry when the normalized session is invalid", () => {
+  const result = shouldLoadTelemetry({
+    selectedSessionId: "session-1",
+    normalizedSessionId: "session-missing",
+    sessionMatchingNormalized: null,
+  });
+
+  assert.equal(result, false);
+});

--- a/web/types/custom-node/index.d.ts
+++ b/web/types/custom-node/index.d.ts
@@ -12,6 +12,14 @@ declare module "node:test" {
 
   export interface MockTracker {
     timers: MockTimers;
+    fn: <T extends (...args: any[]) => any>(implementation?: T) => T & {
+      mock: {
+        calls: Array<{ arguments: Parameters<T> }>;
+      };
+    };
+    module: (specifier: string, factory: () => Record<string, unknown>) => void;
+    reset: () => void;
+    restoreAll: () => void;
   }
 
   export const mock: MockTracker;
@@ -60,6 +68,7 @@ declare module "node:perf_hooks" {
     now(): number;
   };
 }
+
 
 declare const __dirname: string;
 declare const __filename: string;


### PR DESCRIPTION
## Summary
- adjust the dashboard telemetry guard to allow fetching when the first session is selected by fallback while still blocking invalid normalized IDs
- factor the guard logic into a reusable helper and cover the scenarios with focused unit tests alongside node:test typing support for mocks

## Design compliance
- Respects the repo layering by keeping guard orchestration inside the `web` layer in line with System shape guidance. 【F:docs/design-principles.md†L5-L16】
- Adds automated coverage for the new guard behaviour as required by the testing principles. 【F:docs/design-principles.md†L69-L73】
- Prevents confusing error states and supports recovery, matching the UX error-handling guidance. 【F:docs/ux-principles.md†L18-L20】

## Testing
- `npm test` *(aborted after >12 minutes of TypeScript compilation; see execution log)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9a7b07cc8321bd3706e75926e3a2