### PR TITLE
Add CI workflow with Postgres service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    services:
+      postgres:
+        image: postgres:15
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run CI tasks from the web workspace
- provision a Postgres service and run prisma generation, lint, tests, and build commands

## Design compliance
- No user-facing or architectural changes; `docs/design-principles.md` and `docs/ux-principles.md` remain satisfied.

## Testing
- Not run (CI configuration only)

## Risk & Rollback
- Low risk: affects only GitHub Actions CI configuration.
- Rollback by reverting this commit.


------
https://chatgpt.com/codex/tasks/task_e_68ceb30dec9483219e0c5169a781a529